### PR TITLE
Remove gerund in left nav titles

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -58,7 +58,7 @@ nav:
         - API Concepts: apis/api-concepts.md
         - Create and Publish Your First API: apis/create-and-publish-your-first-api.md
     - Observabilty:
-          Perform Root Cause Analysis: observability/root-cause-analysis.md
+          Perform Root Cause Analysis: observability/perform-root-cause-analysis.md
 # Extensions
 markdown_extensions:
     - markdown.extensions.admonition

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -58,7 +58,7 @@ nav:
         - API Concepts: apis/api-concepts.md
         - Create and Publish Your First API: apis/create-and-publish-your-first-api.md
     - Observabilty:
-          Performing Root Cause Analysis: observability/root-cause-analysis.md
+          Perform Root Cause Analysis: observability/root-cause-analysis.md
 # Extensions
 markdown_extensions:
     - markdown.extensions.admonition


### PR DESCRIPTION
## Purpose
Changed `Performing Root Cause Analysis` to `Perform Root Cause Analysis` because we have avoided gerunds in all other left nav titles.