### PR TITLE
Fix the link of the Choreo Docs site logo

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -19,7 +19,7 @@
 site_name: Choreo Documentation
 site_description: Choreo Learning Portal
 site_author: WSO2
-site_url: https://wso2.com/choreo/docs/en/
+site_url: https://wso2.com/choreo/docs/
 
 # Repository
 repo_name: wso2/docs-choreo-dev


### PR DESCRIPTION
## Purpose
> Corrects wso2-enterprise/choreo#4876