### PR TITLE
change font to Montserrat

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -42,6 +42,8 @@ theme:
     highlightjs: true
     feature:
         tabs: true
+    font:
+        text: 'Montserrat'
     language: 'en'
 #Breaks build if there's a warning
 strict: true


### PR DESCRIPTION
## Purpose
Changed font to Montserrat based on @madhuramendis's feedback. 
The new font looks as follows:
![Screenshot from 2021-06-15 17-12-00](https://user-images.githubusercontent.com/7173347/122046694-de4d6980-cdfc-11eb-8598-51445258c791.png)
![Screenshot from 2021-06-15 17-12-08](https://user-images.githubusercontent.com/7173347/122046698-df7e9680-cdfc-11eb-903d-5b6a50ed2e32.png)
![Screenshot from 2021-06-15 17-12-17](https://user-images.githubusercontent.com/7173347/122046706-e0afc380-cdfc-11eb-9485-644998787357.png)

Fixes #https://github.com/wso2-enterprise/choreo/issues/4658
