### PR TITLE
Revert "Add Media Queries to Fix Responsive Issue on Breadcrumbs"

### DIFF
--- a/en/theme/material/assets/stylesheets/choreo-docs-theme.css
+++ b/en/theme/material/assets/stylesheets/choreo-docs-theme.css
@@ -335,17 +335,12 @@ a.cChoreoDocsButtons.localLink {
     text-align: center;
     border: 1px solid gray;
 }
-@media screen and (min-width: 1541px) {
 
-    .container {
-        max-width: 920px;
-    }
-} 
 @media screen and (max-width: 1540px) {
 
-    .container {
-        max-width: 920px;
-    }
+.container {
+	max-width: 970px;
+}
 } 
 
 @media screen and (max-width: 1400px) {


### PR DESCRIPTION
Reverts wso2/docs-choreo-dev#150

Reverting as it reduce the text area significantly and merged to main branch by a mistake.
Ideally we should move breadcrumbs only, not the text area.

<img width="1619" alt="image" src="https://user-images.githubusercontent.com/16300038/122458009-efe56b80-cfcc-11eb-8a8e-0bc75ccd043b.png">


![image](https://user-images.githubusercontent.com/16300038/122458531-8a45af00-cfcd-11eb-8ad0-c8a83babafac.png)
