### PR TITLE
Refer to connector calls using a standardized term

### DIFF
--- a/en/docs/observability/analyze-performance.md
+++ b/en/docs/observability/analyze-performance.md
@@ -16,7 +16,7 @@ The Performance Analyzer tool generates forecasts based on the following assumpt
 
 - For service-based applications the overhead of non-I/O operations is negligible.
 - The service being evaluated is allocated sufficient resources, and therefore, it is not a bottleneck.
-- Sufficient historical data is available for each service operation or connector call considered during the analysis.
+- Sufficient historical data is available for each service operation or API call considered during the analysis.
 
 ## Access the Performance Analyzer tool
 

--- a/en/docs/observability/analyze-performance.md
+++ b/en/docs/observability/analyze-performance.md
@@ -16,7 +16,7 @@ The Performance Analyzer tool generates forecasts based on the following assumpt
 
 - For service-based applications the overhead of non-I/O operations is negligible.
 - The service being evaluated is allocated sufficient resources, and therefore, it is not a bottleneck.
-- Sufficient historical data is available for each service operation or API call considered during the analysis.
+- Sufficient historical data is available for each service operation or connector call considered during the analysis.
 
 ## Access the Performance Analyzer tool
 
@@ -49,7 +49,7 @@ You can derive insights about the performance as follows:
     
     In the above example, the **Latency** graph indicates that when the user count is 50, the forecasted time taken to process one request is 10.37 seconds.
     
-- If you want to check the forecasted latency per API call operation for a specific user count, click over that user count in either the **Throughput** or **Latency** graph.
+- If you want to check the forecasted latency per connector call operation for a specific user count, click over that user count in either the **Throughput** or **Latency** graph.
 
     ![Latency per connector forecast](../assets/img/perf-analyzer/latency-per-connector-forecast.png){.cInlineImage-full}
     

--- a/en/docs/observability/analyze-performance.md
+++ b/en/docs/observability/analyze-performance.md
@@ -49,7 +49,7 @@ You can derive insights about the performance as follows:
     
     In the above example, the **Latency** graph indicates that when the user count is 50, the forecasted time taken to process one request is 10.37 seconds.
     
-- If you want to check the forecasted latency per connector call operation for a specific user count, click over that user count in either the **Throughput** or **Latency** graph.
+- If you want to check the forecasted latency per API call operation for a specific user count, click over that user count in either the **Throughput** or **Latency** graph.
 
     ![Latency per connector forecast](../assets/img/perf-analyzer/latency-per-connector-forecast.png){.cInlineImage-full}
     

--- a/en/docs/observability/perform-root-cause-analysis.md
+++ b/en/docs/observability/perform-root-cause-analysis.md
@@ -42,7 +42,7 @@ The actions you can perform are as follows:
 
 - **View the number of successful requests and errors**
 
-    To do this, hold the pointer over the area of the graph that shows the required time interval. The throughput graph displays the number of successes over the graph as shown in the above image (in this example it displays 296 successes and 2512.43 errors). The low-code diagram displays the success rate for each connector.
+    To do this, hold the pointer over the area of the graph that shows the required time interval. The throughput graph displays the number of successes over the graph as shown in the above image (in this example it displays 296 successes and 2512.43 errors). The low-code diagram displays the success rate for each connector call.
     
 - **View log entries**
 

--- a/en/docs/observability/perform-root-cause-analysis.md
+++ b/en/docs/observability/perform-root-cause-analysis.md
@@ -42,7 +42,7 @@ The actions you can perform are as follows:
 
 - **View the number of successful requests and errors**
 
-    To do this, hold the pointer over the area of the graph that shows the required time interval. The throughput graph displays the number of successes over the graph as shown in the above image (in this example it displays 296 successes and 2512.43 errors). The low-code diagram displays the success rate for each connector call.
+    To do this, hold the pointer over the area of the graph that shows the required time interval. The throughput graph displays the number of successes over the graph as shown in the above image (in this example it displays 296 successes and 2512.43 errors). The low-code diagram displays the success rate for each API call.
     
 - **View log entries**
 


### PR DESCRIPTION
## Purpose
> At present, Root Cause Analysis agep states that the success rate is displayed per *connector* and Performance Analysis page states that the performance details are displayed per *API call". This PR changes this in both pages to refer to it by the standard term "connector call".

