### PR TITLE
Remove \ in md table

### DIFF
--- a/en/docs/get-started/quick-start-guide.md
+++ b/en/docs/get-started/quick-start-guide.md
@@ -76,7 +76,7 @@ Follow this procedure to further develop the API by adding a new resource and si
      |-----------------|-----------------------|
      | **HTTP Method** | `GET` |
      | **Path** | `personalizedMessage` |
-     | **Return Type** | `string\|error` |
+     | **Return Type** | `string|error` |
      
 
 4. Click **Advanced** and then click **+ Add Query Param** to add a query parameter with the following values to get a name as an input:


### PR DESCRIPTION
## Purpose
> A \ character was added before the pipeline in the `string|error` return value because we thought it that the pipeline used within an md table affects the way the md table is rendered. However, the table was not properly rendered only in the Git preview.

This return value is properly rendered via mk docs. Including the \ results in the return value being incorrectly displayed. Therefore, this character was removed.

