### PR TITLE
Revert "Add CookiePro production script"

### DIFF
--- a/en/theme/material/base.html
+++ b/en/theme/material/base.html
@@ -95,11 +95,11 @@
     {% endblock %}
     {% block extrahead %}{% endblock %}
     
-    <!-- CookiePro Cookies Consent Notice start for wso2.com -->
-    <script type="text/javascript" src="https://cookie-cdn.cookiepro.com/consent/486163bc-a8c5-40d8-b185-c707cc718a23/OtAutoBlock.js" ></script>
-    <script src="https://cookie-cdn.cookiepro.com/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="486163bc-a8c5-40d8-b185-c707cc718a23" ></script>
+    <!-- CookiePro Cookies Consent Notice start -->
+    <script type="text/javascript" src="https://cookie-cdn.cookiepro.com/consent/486163bc-a8c5-40d8-b185-c707cc718a23-test/OtAutoBlock.js" ></script>
+    <script src="https://cookie-cdn.cookiepro.com/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="486163bc-a8c5-40d8-b185-c707cc718a23-test" ></script>
     <script src="https://wso2.com//sites/all/themes/wso2_d7/js/cookie-revoke.js"></script>
-    <!-- CookiePro Cookies Consent Notice end for wso2.com -->
+    <!-- CookiePro Cookies Consent Notice end -->
     
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">


### PR DESCRIPTION
Reverts wso2/docs-choreo-dev#606

Reverting because the plan is to push the CookiePro consent via the GTM code.