### PR TITLE
Remove CookiePro consent script

### DIFF
--- a/en/theme/material/base.html
+++ b/en/theme/material/base.html
@@ -95,12 +95,6 @@
     {% endblock %}
     {% block extrahead %}{% endblock %}
     
-    <!-- CookiePro Cookies Consent Notice start for wso2.com -->
-    <script type="text/javascript" src="https://cookie-cdn.cookiepro.com/consent/486163bc-a8c5-40d8-b185-c707cc718a23/OtAutoBlock.js" ></script>
-    <script src="https://cookie-cdn.cookiepro.com/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="486163bc-a8c5-40d8-b185-c707cc718a23" ></script>
-    <script src="https://wso2.com//sites/all/themes/wso2_d7/js/cookie-revoke.js"></script>
-    <!-- CookiePro Cookies Consent Notice end for wso2.com -->
-    
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
     <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Purpose
Remove the CookiePro consent script because the plan is to push the consent via GTM code.