### PR TITLE
add an external IdP hyperlink under Access token for production section was corrected.

### DIFF
--- a/en/docs/developer-portal/manage-application.md
+++ b/en/docs/developer-portal/manage-application.md
@@ -35,7 +35,7 @@ Depending on your use case, you can generate an access token using one of the tw
 
 Token Exchange grant type requires you to pass a subject_token as a parameter in the token invocation call. You can obtain a subject token (id token) by using the `open_id` scope. Follow the steps below to generate an access token from the IdP along with the subject token:
 
-1. Register the IdP in Choreo by following the steps in the section [add an external IdP](../../manage/connect-to-an-external-identity-provider/#step-1-add-an-external-idp/).
+1. Register the IdP in Choreo by following the steps in the section [add an external IdP](https://wso2.com/choreo/docs/administration/connect-to-an-external-identity-provider/#step-1-add-an-external-idp).
 
 2. Generate a token from the registered IdP with the `openId` scope and retrieve the `id_token` from the token response.  
                 

--- a/en/docs/developer-portal/manage-application.md
+++ b/en/docs/developer-portal/manage-application.md
@@ -35,7 +35,7 @@ Depending on your use case, you can generate an access token using one of the tw
 
 Token Exchange grant type requires you to pass a subject_token as a parameter in the token invocation call. You can obtain a subject token (id token) by using the `open_id` scope. Follow the steps below to generate an access token from the IdP along with the subject token:
 
-1. Register the IdP in Choreo by following the steps in the section [add an external IdP](https://wso2.com/choreo/docs/administration/connect-to-an-external-identity-provider/#step-1-add-an-external-idp).
+1. Register the IdP in Choreo by following the steps in the section [add an external IdP](../administration/connect-to-an-external-identity-provider/#step-1-add-an-external-idp/).
 
 2. Generate a token from the registered IdP with the `openId` scope and retrieve the `id_token` from the token response.  
                 


### PR DESCRIPTION

## Purpose
> add an external IdP hyperlink under Access token for production section was wrong.

## Goals
> Correct the relevant hyperlink.

## Approach
> Correct link was added.