### PR TITLE
Remove the use of term `Choreo iPaaS`

### DIFF
--- a/en/docs/develop-components/develop-integrations/develop-a-scheduled-integration.md
+++ b/en/docs/develop-components/develop-integrations/develop-a-scheduled-integration.md
@@ -1,10 +1,10 @@
 # Develop a Scheduled Integration
 
-Choreo iPaaS is a versatile integration platform that allows you to create various types of integrations depending on your requirement. 
+Choreo is a versatile integration platform that allows you to create various types of integrations depending on your requirement. 
 
-If you have a requirement to automatically run a specific integration at regular intervals, you can use Choreo iPaaS to develop a scheduled integration.  This type of integration can automate the synchronization of data between different systems at specified intervals, reducing errors and improving productivity by eliminating the need for manual intervention.
+If you have a requirement to automatically run a specific integration at regular intervals, you can use Choreo to develop a scheduled integration.  This type of integration can automate the synchronization of data between different systems at specified intervals, reducing errors and improving productivity by eliminating the need for manual intervention.
 
-This guide walks you through the steps to develop, deploy, test, and observe a scheduled integration using Choreo iPaaS.  
+This guide walks you through the steps to develop, deploy, test, and observe a scheduled integration using Choreo.  
 
 In this guide, you will:
 

--- a/en/docs/develop-components/develop-integrations/develop-an-event-triggered-integration.md
+++ b/en/docs/develop-components/develop-integrations/develop-an-event-triggered-integration.md
@@ -1,8 +1,8 @@
 # Develop an Event-Triggered Integration
 
-An event-triggered integration executes predefined actions in response to specific events. Choreo iPaaS simplifies the process of creating and deploying such integrations.
+An event-triggered integration executes predefined actions in response to specific events. Choreo simplifies the process of creating and deploying such integrations.
 
-This guide walks you through the steps to create and deploy an event-triggered integration using Ballerina and Choreo iPaaS. 
+This guide walks you through the steps to create and deploy an event-triggered integration using Ballerina and Choreo. 
 
 In this guide, you will build a simple integration that sends an email notification whenever a new issue is created in a GitHub repository.
 

--- a/en/docs/develop-components/develop-integrations/develop-an-integration-with-integration-studio.md
+++ b/en/docs/develop-components/develop-integrations/develop-an-integration-with-integration-studio.md
@@ -1,6 +1,6 @@
 # Develop an Integration with Integration Studio
 
-The seamless integration of APIs, microservices, applications, and data across different languages and formats requires the ability to expose integrations as APIs. Choreo iPaaS simplifies building, deploying, and managing integration components, making it easy for you to quickly expose integrations as APIs.
+The seamless integration of APIs, microservices, applications, and data across different languages and formats requires the ability to expose integrations as APIs. Choreo simplifies building, deploying, and managing integration components, making it easy for you to quickly expose integrations as APIs.
 
 This guide walks you through the steps to expose an integration you created in WSO2 Integration Studio as an API in Choreo. 
 

--- a/en/docs/develop-components/work-with-the-micro-integrator-runtime-in-choreo.md
+++ b/en/docs/develop-components/work-with-the-micro-integrator-runtime-in-choreo.md
@@ -1,12 +1,12 @@
 # Work with the Micro Integrator Runtime in Choreo
 
-WSO2 Micro Integrator (WSO2 MI) is a lightweight, high-performance integration runtime. It allows you to run integrations developed using WSO2 Integration Studio within the Choreo iPaaS platform. 
+WSO2 Micro Integrator (WSO2 MI) is a lightweight, high-performance integration runtime. It allows you to run integrations developed using WSO2 Integration Studio within Choreo. 
 
 The topics on this page walk you through the key aspects you need to understand to use the WSO2 MI runtime effectively in Choreo.
 
 ## Integration types
 
-Choreo iPaaS supports the following WSO2 MI integrations that cater to different use cases and requirements. Each integration type serves a specific purpose. Therefore, it is essential to understand their differences to easily choose the most appropriate integration for your use case.
+Choreo supports the following WSO2 MI integrations that cater to different use cases and requirements. Each integration type serves a specific purpose. Therefore, it is essential to understand their differences to easily choose the most appropriate integration for your use case.
 
 - **Integration as an API**: Exposes an integration as an API via HTTP, making it possible to create a RESTful interface for your integration services. This type is ideal for scenarios where you need to provide an API for external systems or clients to interact with your integration.
 - **Event-triggered integration**: Triggers an integration based on external events such as messages arriving on a queue or updates in a database. This type is well-suited for implementing event-driven architectures or responding to changes in your system's environment.


### PR DESCRIPTION
## Purpose
Remove the use of the terms `Choreo iPaaS` and `Choreo APIM` to align with the latest messaging.