### PR TITLE
Update documentation related to service endpoint types

### DIFF
--- a/en/docs/develop-components/configure-endpoints-body.md
+++ b/en/docs/develop-components/configure-endpoints-body.md
@@ -7,9 +7,9 @@ Choreo defines endpoints by combining port binding, protocol, endpoint name, net
 | ----- | ----------- |
 | Name | A unique identifier for the endpoint within the service component. |
 | Port | The network port on which the endpoint is accessible. |
-| Type | The communication protocol used by the endpoint (e.g., HTTP, HTTPS, gRPC, etc.). |
+| Type | The communication method used by the service component. Possible types: REST, GraphQL, gRPC, UDP, and TCP. |
 | Network Visibility | Determines the level of visibility of an endpoint. Possible values are: <ul><li>Project: Allows components within the same project to access the endpoint.</li><li>Organization: Allows any component within the same organization to access the endpoint but restricts access to components outside the organization.</li><li>Public: Allows any client to access the endpoint, regardless of location or organization.</li></ul> |
-| Schema | specifies the structure and format of the data exchanged through the endpoint. |
+| Schema | Specifies the structure and format of the data exchanged through the endpoint. |
 | Context (HTTP and GraphQL only) | A context path that you add to the endpoint's URL for routing purposes. |
 
 ## Configure endpoints
@@ -59,7 +59,7 @@ The `endpoints.yaml` file has a specific structure and contains the following de
 | **version**          | Required     | The version of the `endpoints.yaml` file.                                           |
 | **name**             | Required     | A unique name for the endpoint, which Choreo will use to generate the managed API.|
 | **port**             | Required     | The numeric port value that gets exposed via this endpoint.                      |
-| **type**             | Required     | The type of traffic this endpoint is accepting, such as `REST`, `GraphQL`, or `gRPC`. Currently, the MI preset supports only the `REST` type.                                         |
+| **type**             | Required     | The type of traffic this endpoint is accepting, such as `REST`, `GraphQL`, `gRPC`, `UDP`or `TCP`. Currently, the MI preset supports only the `REST` type.                                         |
 | **networkVisibility**| Required     | The network level visibility of this endpoint, which defaults to `Project` if not specified. Accepted values are `Project`, `Organization`, or `Public`.|
 | **context**          | Required     | The context (base path) of the API that Choreo exposes via this endpoint.        |
 | **schemaFilePath**   | Required     | The swagger definition file path. Defaults to the wildcard route if not provided. This field should be a relative path to the project path when using the MI build preset. For REST endpoint types when using the Ballerina or Dockerfile preset, this field should be a relative path to the component root or Docker context .|
@@ -92,7 +92,7 @@ endpoints:
   # +required Numeric port value that gets exposed via this endpoint
   port: 9090
   # +required Type of the traffic this endpoint is accepting. Example: REST, GraphQL, etc.
-  # Allowed values: REST, GraphQL, GRPC
+  # Allowed values: REST, GraphQL, GRPC, UDP, TCP
   type: REST
   # +optional Network level visibility of this endpoint. Defaults to Project
   # Accepted values: Project|Organization|Public.

--- a/en/docs/develop-components/configure-endpoints-body.md
+++ b/en/docs/develop-components/configure-endpoints-body.md
@@ -7,7 +7,7 @@ Choreo defines endpoints by combining port binding, protocol, endpoint name, net
 | ----- | ----------- |
 | Name | A unique identifier for the endpoint within the service component. |
 | Port | The network port on which the endpoint is accessible. |
-| Type | The communication method used by the service component. Possible types: REST, GraphQL, gRPC, UDP, and TCP. |
+| Type | The endpoint protocol. Supported protocols: REST, GraphQL, gRPC, UDP, and TCP. |
 | Network Visibility | Determines the level of visibility of an endpoint. Possible values are: <ul><li>Project: Allows components within the same project to access the endpoint.</li><li>Organization: Allows any component within the same organization to access the endpoint but restricts access to components outside the organization.</li><li>Public: Allows any client to access the endpoint, regardless of location or organization.</li></ul> |
 | Schema | Specifies the structure and format of the data exchanged through the endpoint. |
 | Context (HTTP and GraphQL only) | A context path that you add to the endpoint's URL for routing purposes. |

--- a/en/docs/develop-components/develop-services/develop-a-service.md
+++ b/en/docs/develop-components/develop-services/develop-a-service.md
@@ -4,7 +4,7 @@ Explore how to create, deploy, manage, and observe service components in Choreo.
 
 ## What is a service component?
 
-A service component in Choreo lets you deploy and expose REST, GraphQL, or gRPC services. It is a fundamental building block for creating cloud-native applications in Choreo. They provide a simple and effective way to expose functionality as a service to other components within Choreo or to the outside world.
+A service component in Choreo lets you deploy and expose REST, GraphQL, gRPC, UDP or TCP services. It is a fundamental building block for creating cloud-native applications in Choreo. They provide a simple and effective way to expose functionality as a service to other components within Choreo or to the outside world.
 
 Service components encapsulate business logic and provide standardized interfaces, called endpoints, for communicating with other components or systems. You can deploy and scale services independently, which makes them highly flexible and adaptable to changing workloads.
 

--- a/en/docs/develop-components/develop-services/develop-a-service.md
+++ b/en/docs/develop-components/develop-services/develop-a-service.md
@@ -4,7 +4,7 @@ Explore how to create, deploy, manage, and observe service components in Choreo.
 
 ## What is a service component?
 
-A service component in Choreo lets you deploy and expose REST, GraphQL, gRPC, UDP or TCP services. It is a fundamental building block for creating cloud-native applications in Choreo. They provide a simple and effective way to expose functionality as a service to other components within Choreo or to the outside world.
+A service component in Choreo lets you deploy and expose REST, GraphQL, gRPC, UDP, or TCP services. It is a fundamental building block for creating cloud-native applications in Choreo. They provide a simple and effective way to expose functionality as a service to other components within Choreo or to the outside world.
 
 Service components encapsulate business logic and provide standardized interfaces, called endpoints, for communicating with other components or systems. You can deploy and scale services independently, which makes them highly flexible and adaptable to changing workloads.
 


### PR DESCRIPTION
## Purpose
> Update service endpoint types and the type definition. Added support for new service components UDP and TCP, these types needs to be added to the `endpoints.yaml` file respectively.

## Approach
> Modified `choreo/docs/develop-components/develop-services/develop-a-service/#what-is-a-service-component`
<img width="1006" alt="Screenshot 2023-08-29 at 17 09 41" src="https://github.com/wso2/docs-choreo-dev/assets/30908235/a87e79d3-4de5-4ffd-83eb-d32494a6c59f">

> Modified `choreo/docs/develop-components/develop-services/develop-a-service/#learn-the-endpointsyaml-file`
<img width="1005" alt="Screenshot 2023-08-29 at 17 12 22" src="https://github.com/wso2/docs-choreo-dev/assets/30908235/45dc4adb-9636-4ba2-b51d-fcee08f35810">

<img width="1001" alt="Screenshot 2023-08-29 at 17 13 20" src="https://github.com/wso2/docs-choreo-dev/assets/30908235/8af7b43c-01a2-40ad-8353-04139c9f031a">

## Release note
>  Introducing support for deploying new service types, specifically UDP and TCP service components, as Docker containers. Modify the `endpoints.yaml` configuration file to accommodate the selection of either UDP or TCP as the desired service type.

## Related PRs
Resolves https://github.com/wso2-enterprise/choreo/issues/23418
Relates to the PR https://github.com/wso2-enterprise/choreodp-rudder/pull/969