### PR TITLE
Update the storage acc name to newly created storage acc in Choreo prod subscription for upcoming prod deployment pipeline

### DIFF
--- a/.azure/prod-build.yaml
+++ b/.azure/prod-build.yaml
@@ -90,5 +90,5 @@ jobs:
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
-        az storage blob delete-batch -s '$web' --account-name "choreostgdocs27"
-        az storage blob upload-batch -d '$web' --account-name "choreostgdocs27" -s "$(Build.ArtifactStagingDirectory)/dist/en/"
+        az storage blob delete-batch -s '$web' --account-name "choreoproddocs66"
+        az storage blob upload-batch -d '$web' --account-name "choreoproddocs66" -s "$(Build.ArtifactStagingDirectory)/dist/en/"


### PR DESCRIPTION
## Purpose

Update the storage acc name to newly created storage acc in Choreo prod subscription for upcoming prod deployment pipeline (previously it was pointed to a storage account in lower env for RnD purposes)

Reltaed issue:- https://github.com/wso2-enterprise/choreo/issues/24078