### PR TITLE
Fail the pipeline upon build failure

### DIFF
--- a/.azure/dev-build-v2.yaml
+++ b/.azure/dev-build-v2.yaml
@@ -2,90 +2,88 @@ trigger:
   batch: true
   branches:
     include:
-    - dev
+      - dev
 
 pr: none
 
 jobs:
-- job: GenerateDevDocSite
+  - job: GenerateDevDocSite
 
-  pool:
-    vmImage: 'ubuntu-latest'
-  strategy:
-    matrix:
-      Python38:
-        python.version: '3.8'
-  steps:
-  - task: usePythonVersion@0
-    inputs:
-      versionSpec: '3.8'
-  - script: |
-      echo "[INFO] install required packages"
-      pip3 install zipp==3.0.0
-      pip3 install pathlib2==2.3.5
-      pip3 install virtualenv==20.0.0 --ignore-installed six
-      virtualenv --version
-      virtualenv -v -p python3.6 /env
-      export PATH=/env/bin:$PATH
-      echo $PATH
+    pool:
+      vmImage: 'ubuntu-latest'
+    strategy:
+      matrix:
+        Python38:
+          python.version: '3.8'
+    steps:
+      - task: usePythonVersion@0
+        inputs:
+          versionSpec: '3.8'
+      - script: |
+          echo "[INFO] install required packages"
+          pip3 install zipp==3.0.0
+          pip3 install pathlib2==2.3.5
+          pip3 install virtualenv==20.0.0 --ignore-installed six
+          virtualenv --version
+          virtualenv -v -p python3.6 /env
+          export PATH=/env/bin:$PATH
+          echo $PATH
+          
+          pip3 install -U --upgrade mkdocs==1.0.4
+          pip3 install Pygments==2.14.0
+          pip3 install pymdown-extensions==9.10
+          pip3 install mkdocs-minify-plugin==0.6.2
+          pip3 install mkdocs-markdownextradata-plugin==0.2.5
+          pip3 install mkdocs-redirects==1.2.0
+          pip3 install pathlib==1.0.1
+          pip3 install -U mkdocs-material==9.1.2
+          pip3 install markdown-include==0.8.1
+          pip3 install markdown==3.2.1
+          pip3 install mkdocs-redirects==1.2.0
+          pip3 install mkdocs-exclude==1.0.2
+          pip3 install -U Jinja2==3.1.0
+          pip3 install mkdocs-glightbox==0.3.4
+          pip3 install mkdocs-include-markdown-plugin==4.0.4
+          pip3 freeze | grep mkdocs-material
+          
+          npm i markdown-spellcheck@1.3.1 -g
+          npm install -g markdown-link-check@3.10.3
+          
+          echo "[INFO] check versions"
+          python3 --version
+          pip3 --version
+          which python3
+          which python
+          which mkdocs
+          pip3 --version
+          python --version
+          mkdocs --version
+          
+          echo "[INFO] starting doc site build"
+          set -eo pipefail
+          
+          echo "[INFO] obtaining directories with a serve.sh script"
+          mapfile -t build_scripts < <(find -- * -maxdepth 1 -name "serve.sh")
+          
+          for build_script in "${build_scripts[@]}"; do
+            build_dir="$(dirname "${build_script}")"
+            echo "[INFO] building site in $build_dir"
+            mkdir -p $(Build.ArtifactStagingDirectory)/dist/${build_dir}
+            cd "$build_dir"
+            ./serve.sh
+            mv -f site/* $(Build.ArtifactStagingDirectory)/dist/${build_dir}/
+            cd -
+          done
+          
+          echo "[INFO] listing files in $(Build.ArtifactStagingDirectory)/dist/"
+          ls -l $(Build.ArtifactStagingDirectory)/dist/
 
-      pip3 install -U --upgrade mkdocs==1.0.4
-      pip3 install Pygments==2.14.0
-      pip3 install pymdown-extensions==9.10
-      pip3 install mkdocs-minify-plugin==0.6.2
-      pip3 install mkdocs-markdownextradata-plugin==0.2.5
-      pip3 install mkdocs-redirects==1.2.0
-      pip3 install pathlib==1.0.1
-      pip3 install -U mkdocs-material==9.1.2
-      pip3 install markdown-include==0.8.1
-      pip3 install markdown==3.2.1
-      pip3 install mkdocs-redirects==1.2.0
-      pip3 install mkdocs-exclude==1.0.2
-      pip3 install -U Jinja2==3.1.0
-      pip3 install mkdocs-glightbox==0.3.4
-      pip3 install mkdocs-include-markdown-plugin==4.0.4
-      pip3 freeze | grep mkdocs-material
-      
-      npm i markdown-spellcheck@1.3.1 -g
-      npm install -g markdown-link-check@3.10.3
-            
-      echo "[INFO] check versions"
-      python3 --version
-      pip3 --version
-      which python3
-      which python
-      which mkdocs
-      pip3 --version
-      python --version
-      mkdocs --version
-
-      echo "[INFO] starting doc site build"
-      set -eo pipefail
-      
-      echo "[INFO] obtaining directories with a serve.sh script"
-      mapfile -t build_scripts < <(find -- * -maxdepth 1 -name "serve.sh")
-      
-      echo "PWD: $(pwd)"
-      for build_script in "${build_scripts[@]}"; do
-        build_dir="$(dirname "${build_script}")"
-        echo "[INFO] building site in $build_dir"
-        mkdir -p $(Build.ArtifactStagingDirectory)/dist/${build_dir}
-        cd "$build_dir"
-        ./serve.sh
-        mv -f site/* $(Build.ArtifactStagingDirectory)/dist/${build_dir}/
-        cd -
-      done
-      echo "PWD: $(pwd)"
-
-      echo "[INFO] listing files in $(Build.ArtifactStagingDirectory)/dist/"
-      ls -l $(Build.ArtifactStagingDirectory)/dist/
-
-#  - task: AzureCLI@2
-#    displayName: Upload files to Azure Storage Account
-#    inputs:
-#      azureSubscription: choreo-docs-site-rg
-#      scriptType: bash
-#      scriptLocation: inlineScript
-#      inlineScript: |
-#        az storage blob sync -c '$web/choreo/docs' --account-name "choreodocsdevstorage" -s "$(Build.ArtifactStagingDirectory)/dist/en/"
-#        az cdn endpoint purge -g choreo-docs-site-rg -n choreodocssitedev --profile-name choreo-docs-dev-cdn --no-wait --content-paths '/*'
+      - task: AzureCLI@2
+        displayName: Upload files to Azure Storage Account
+        inputs:
+          azureSubscription: choreo-docs-site-rg
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            az storage blob sync -c '$web/choreo/docs' --account-name "choreodocsdevstorage" -s "$(Build.ArtifactStagingDirectory)/dist/en/"
+            az cdn endpoint purge -g choreo-docs-site-rg -n choreodocssitedev --profile-name choreo-docs-dev-cdn --no-wait --content-paths '/*'

--- a/.azure/dev-build-v2.yaml
+++ b/.azure/dev-build-v2.yaml
@@ -84,13 +84,7 @@ jobs:
        
           pwd
           mdspell -V
-          mdspell  -n -a --en-us docs/**/*.md -d dictionary/en_US-large
-          mdspell  -n -a --en-us docs/**/**/*.md -d dictionary/en_US-large
-          mdspell  -n -a --en-us mkdocs.yml -d dictionary/en_US-large
-          mdspell  -n -a --en-us theme/material/templates/home-page.html -d dictionary/en_US-large
-          find docs/** -type f -name '*.md'  | xargs -L1 markdown-link-check -c ./markdown-link-check-config.json  --quiet || exit 1
-          find docs/**/* -type f -name '*.md' | xargs -L1 markdown-link-check -c ./markdown-link-check-config.json  --quiet || exit 1
-          mkdocs build -c
+          ./serve.sh
 
           cd ../..
           ls ${cwd}/${dirName}/site/

--- a/.azure/dev-build-v2.yaml
+++ b/.azure/dev-build-v2.yaml
@@ -20,10 +20,7 @@ jobs:
     inputs:
       versionSpec: '3.8'
   - script: |
-      echo "Starting doc site build"
-      python3 --version
-      pip3 --version
-
+      echo "[INFO] install required packages"
       pip3 install zipp==3.0.0
       pip3 install pathlib2==2.3.5
       pip3 install virtualenv==20.0.0 --ignore-installed six
@@ -32,68 +29,55 @@ jobs:
       export PATH=/env/bin:$PATH
       echo $PATH
 
-      which python3
-      which python
-
-
       pip3 install -U --upgrade mkdocs==1.0.4
       pip3 install Pygments==2.14.0
       pip3 install pymdown-extensions==9.10
       pip3 install mkdocs-minify-plugin==0.6.2
-
-
       pip3 install mkdocs-markdownextradata-plugin==0.2.5
       pip3 install mkdocs-redirects==1.2.0
       pip3 install pathlib==1.0.1
-
       pip3 install -U mkdocs-material==9.1.2
-
-      which mkdocs
       pip3 install markdown-include==0.8.1
       pip3 install markdown==3.2.1
       pip3 install mkdocs-redirects==1.2.0
       pip3 install mkdocs-exclude==1.0.2
       pip3 install -U Jinja2==3.1.0
       pip3 install mkdocs-glightbox==0.3.4
-
       pip3 install mkdocs-include-markdown-plugin==4.0.4
+      pip3 freeze | grep mkdocs-material
       
-      echo == versions ==
-
+      npm i markdown-spellcheck@1.3.1 -g
+      npm install -g markdown-link-check@3.10.3
+            
+      echo "[INFO] check versions"
+      python3 --version
+      pip3 --version
+      which python3
+      which python
+      which mkdocs
       pip3 --version
       python --version
       mkdocs --version
-      pip3 freeze | grep mkdocs-material
 
-      echo ========================
-
-      npm i markdown-spellcheck@1.3.1 -g
-      npm install -g markdown-link-check@3.10.3
-
-      echo == Build Script Start ==
-
-      cwd=`pwd`
+      echo "[INFO] starting doc site build"
       set -eo pipefail
-      for dir in ${cwd}/*/; do
-        if [ -d ${f} ]; then
-        dir=${dir%*/}
-        dirName=${dir##*/}
-          if [ ${dirName} != "dist" ]; then
-          mkdir -p $(Build.ArtifactStagingDirectory)/dist/${dirName}
-          cd ${dir}
-       
-          pwd
-          mdspell -V
-          ./serve.sh
-
-          cd ../..
-          ls ${cwd}/${dirName}/site/
-          mv -f ${cwd}/${dirName}/site/* $(Build.ArtifactStagingDirectory)/dist/${dirName}/
-          fi
-        fi
+      
+      echo "[INFO] obtaining directories with a serve.sh script"
+      mapfile -t build_scripts < <(find -- * -maxdepth 1 -name "serve.sh")
+      
+      echo "PWD: $(pwd)"
+      for build_script in "${build_scripts[@]}"; do
+        build_dir="$(dirname "${build_script}")"
+        echo "[INFO] building site in $build_dir"
+        mkdir -p $(Build.ArtifactStagingDirectory)/dist/${build_dir}
+        cd "$build_dir"
+        ./serve.sh
+        mv -f site/* $(Build.ArtifactStagingDirectory)/dist/${build_dir}/
+        cd -
       done
+      echo "PWD: $(pwd)"
 
-      echo "=== After building ==="
+      echo "[INFO] listing files in $(Build.ArtifactStagingDirectory)/dist/"
       ls -l $(Build.ArtifactStagingDirectory)/dist/
 
 #  - task: AzureCLI@2

--- a/.azure/dev-build-v2.yaml
+++ b/.azure/dev-build-v2.yaml
@@ -73,7 +73,7 @@ jobs:
       echo == Build Script Start ==
 
       cwd=`pwd`
-
+      set -eo pipefail
       for dir in ${cwd}/*/; do
         if [ -d ${f} ]; then
         dir=${dir%*/}
@@ -84,7 +84,13 @@ jobs:
        
           pwd
           mdspell -V
-           ./serve.sh
+          mdspell  -n -a --en-us docs/**/*.md -d dictionary/en_US-large
+          mdspell  -n -a --en-us docs/**/**/*.md -d dictionary/en_US-large
+          mdspell  -n -a --en-us mkdocs.yml -d dictionary/en_US-large
+          mdspell  -n -a --en-us theme/material/templates/home-page.html -d dictionary/en_US-large
+          find docs/** -type f -name '*.md'  | xargs -L1 markdown-link-check -c ./markdown-link-check-config.json  --quiet || exit 1
+          find docs/**/* -type f -name '*.md' | xargs -L1 markdown-link-check -c ./markdown-link-check-config.json  --quiet || exit 1
+          mkdocs build -c
 
           cd ../..
           ls ${cwd}/${dirName}/site/
@@ -96,12 +102,12 @@ jobs:
       echo "=== After building ==="
       ls -l $(Build.ArtifactStagingDirectory)/dist/
 
-  - task: AzureCLI@2
-    displayName: Upload files to Azure Storage Account
-    inputs:
-      azureSubscription: choreo-docs-site-rg
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        az storage blob sync -c '$web/choreo/docs' --account-name "choreodocsdevstorage" -s "$(Build.ArtifactStagingDirectory)/dist/en/"
-        az cdn endpoint purge -g choreo-docs-site-rg -n choreodocssitedev --profile-name choreo-docs-dev-cdn --no-wait --content-paths '/*'
+#  - task: AzureCLI@2
+#    displayName: Upload files to Azure Storage Account
+#    inputs:
+#      azureSubscription: choreo-docs-site-rg
+#      scriptType: bash
+#      scriptLocation: inlineScript
+#      inlineScript: |
+#        az storage blob sync -c '$web/choreo/docs' --account-name "choreodocsdevstorage" -s "$(Build.ArtifactStagingDirectory)/dist/en/"
+#        az cdn endpoint purge -g choreo-docs-site-rg -n choreodocssitedev --profile-name choreo-docs-dev-cdn --no-wait --content-paths '/*'

--- a/en/serve.sh
+++ b/en/serve.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
+mdspell -V
 mdspell  -n -a --en-us docs/**/*.md -d dictionary/en_US-large
 mdspell  -n -a --en-us docs/**/**/*.md -d dictionary/en_US-large
 mdspell  -n -a --en-us mkdocs.yml -d dictionary/en_US-large
@@ -6,3 +8,5 @@ mdspell  -n -a --en-us theme/material/templates/home-page.html -d dictionary/en_
 find docs/** -type f -name '*.md'  | xargs -L1 markdown-link-check -c ./markdown-link-check-config.json  --quiet || exit 1 
 find docs/**/* -type f -name '*.md' | xargs -L1 markdown-link-check -c ./markdown-link-check-config.json  --quiet || exit 1
 mkdocs build -c
+
+ls site/

--- a/en/serve.sh
+++ b/en/serve.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 mdspell -V
-mdspell  -n -a --en-us docs/**/*.md -d dictionary/en_US-large
-mdspell  -n -a --en-us docs/**/**/*.md -d dictionary/en_US-large
-mdspell  -n -a --en-us mkdocs.yml -d dictionary/en_US-large
-mdspell  -n -a --en-us theme/material/templates/home-page.html -d dictionary/en_US-large
-find docs/** -type f -name '*.md'  | xargs -L1 markdown-link-check -c ./markdown-link-check-config.json  --quiet || exit 1 
-find docs/**/* -type f -name '*.md' | xargs -L1 markdown-link-check -c ./markdown-link-check-config.json  --quiet || exit 1
+mdspell -n -a --en-us docs/**/*.md -d dictionary/en_US-large
+mdspell -n -a --en-us docs/**/**/*.md -d dictionary/en_US-large
+mdspell -n -a --en-us mkdocs.yml -d dictionary/en_US-large
+mdspell -n -a --en-us theme/material/templates/home-page.html -d dictionary/en_US-large
+find docs/** -type f -name '*.md' | xargs -L1 markdown-link-check -c ./markdown-link-check-config.json --quiet || exit 1
+find docs/**/* -type f -name '*.md' | xargs -L1 markdown-link-check -c ./markdown-link-check-config.json --quiet || exit 1
 mkdocs build -c
 
 ls site/

--- a/en/serve.sh
+++ b/en/serve.sh
@@ -1,5 +1,4 @@
-#! /bin/sh
-set -e
+#!/bin/bash
 mdspell  -n -a --en-us docs/**/*.md -d dictionary/en_US-large
 mdspell  -n -a --en-us docs/**/**/*.md -d dictionary/en_US-large
 mdspell  -n -a --en-us mkdocs.yml -d dictionary/en_US-large


### PR DESCRIPTION
## Purpose

According to the previous implementation, content is uploaded to the storage account even if a deadlink is found. When the deadlink is found, the site won't be built and we will have an empty directory under `$(Build.ArtifactStagingDirectory)/dist`. Syncing this empty directory to the storage account will cause the site to be unavailable.

This PR addresses the above issue and fails the pipeline upon such a failure. Storage account will only be synced if no previous command has returned a non-zero exit code