### PR TITLE
Remove `Manage Configurations` under `Develop Components` from the left nav

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -121,7 +121,6 @@ nav:
       - Deploy a Containerized Application: develop-components/deploy-a-containerized-application.md  
       - Sharing and Reusing Services: develop-components/sharing-and-reusing-services.md
       - Manage Deployment Tracks for Choreo Components: develop-components/manage-deployment-tracks-for-choreo-components.md
-      - Manage Configurations: develop-components/manage-configurations.md
       - Configure Mutual TLS Between Components: develop-components/configure-mutual-tls-between-components.md
       - Configure Endpoints: develop-components/configure-endpoints.md
       - Develop Components Using VS Code: develop-components/develop-components-using-vs-code.md


### PR DESCRIPTION
Remove `Manage Configurations` under `Develop Components` from the left nav. The necessary info is documented in the following sections: 
- https://wso2.com/choreo/docs/choreo-concepts/configuration-management/ 
- https://wso2.com/choreo/docs/devops-and-ci-cd/manage-configurations-and-secrets/