### PR TITLE
Update: All organizations in the paid tier can adjust resource requests and limits

### DIFF
--- a/en/docs/devops-and-ci-cd/configure-container-resources-commands-and-arguments.md
+++ b/en/docs/devops-and-ci-cd/configure-container-resources-commands-and-arguments.md
@@ -28,7 +28,7 @@ The following topics walk you through the container configuration changes you ca
 ### Update resource requests and limits
 
 !!! info "Note"
-    The capability to update resource requests and limits is only available in the paid tier.
+    The capability to update resource requests and limits is only available in in paid pricing plans.
 
 To update resource requests and limits, move the corresponding slider to a required position. A resource request cannot be less than its corresponding limit.
 

--- a/en/docs/devops-and-ci-cd/configure-container-resources-commands-and-arguments.md
+++ b/en/docs/devops-and-ci-cd/configure-container-resources-commands-and-arguments.md
@@ -28,7 +28,7 @@ The following topics walk you through the container configuration changes you ca
 ### Update resource requests and limits
 
 !!! info "Note"
-    The capability to update resource requests and limits is only available in in paid pricing plans.
+    The capability to update resource requests and limits is only available in paid pricing plans.
 
 To update resource requests and limits, move the corresponding slider to a required position. A resource request cannot be less than its corresponding limit.
 

--- a/en/docs/devops-and-ci-cd/configure-container-resources-commands-and-arguments.md
+++ b/en/docs/devops-and-ci-cd/configure-container-resources-commands-and-arguments.md
@@ -28,7 +28,7 @@ The following topics walk you through the container configuration changes you ca
 ### Update resource requests and limits
 
 !!! info "Note"
-    The capability to update resource requests and limits is only allowed in private data plane organizations.
+    The capability to update resource requests and limits is only available in the paid tier.
 
 To update resource requests and limits, move the corresponding slider to a required position. A resource request cannot be less than its corresponding limit.
 


### PR DESCRIPTION
## Purpose

All organizations in the paid tier can now adjust resource requests and limits - previously these settings were allowed for components running in private data planes.
