### PR TITLE
Update "Add Connection Configuration" Section for New Component.yaml Descriptor Files

### DIFF
--- a/en/.spelling
+++ b/en/.spelling
@@ -15,6 +15,7 @@ buildpacks
 Temurin
 RabbitMQ
 SalesOrderQueue
+v1.1
 1.x
 12.x.x
 14.x.x 

--- a/en/docs/develop-components/sharing-and-reusing/use-a-connection-in-your-service.md
+++ b/en/docs/develop-components/sharing-and-reusing/use-a-connection-in-your-service.md
@@ -12,7 +12,7 @@ You can consume a Choreo-deployed service within another service. Consuming conn
 
 ### Step 1: Add connection configurations
 
-To integrate another service into your application, click the appropriate tab below based on your current configuration file version and follow the step-by-step instructions:
+To integrate another service into your application, click the appropriate tab below based on your current configuration file and follow the step-by-step instructions:
 
 === "Component.yaml file"
   
@@ -61,7 +61,7 @@ To integrate another service into your application, click the appropriate tab be
           | ConsumerSecret | string     | Consumer secret of the Choreo service | false         | true         |
           | TokenURL       | string     | Token URL of the STS                  | false         | false        |
 
-    <h3> Step 2: Read configurations within the application </h3>
+    ### Step 2: Read configurations within the application
 
     Once you add the connection configuration snippet, you can proceed to read those configurations within your application. The steps to follow depend on the programming language you are using.
 
@@ -122,7 +122,7 @@ To integrate another service into your application, click the appropriate tab be
           | ConsumerSecret | string     | Consumer secret of the Choreo service | false         | true         |
           | TokenURL       | string     | Token URL of the STS                  | false         | false        |
 
-    ### Step 2: Read configurations within the application
+    <h3> Step 2: Read configurations within the application </h3>
 
     Once you add the connection configuration snippet, you can proceed to read those configurations within your application. The steps to follow depend on the programming language you are using.
 

--- a/en/docs/develop-components/sharing-and-reusing/use-a-connection-in-your-service.md
+++ b/en/docs/develop-components/sharing-and-reusing/use-a-connection-in-your-service.md
@@ -59,6 +59,16 @@ To integrate another service into your application, click the appropriate tab be
           | ConsumerSecret | string     | Consumer secret of the Choreo service | false         | true         |
           | TokenURL       | string     | Token URL of the STS                  | false         | false        |
 
+    ### Step 2: Read configurations within the application
+
+    Once you add the connection configuration snippet, you can proceed to read those configurations within your application. The steps to follow depend on the programming language you are using.
+
+    The following is a sample code snippet in NodeJS:
+
+    ``` java
+    const serviceURL = process.env.CHOREO_<CONNECTION_NAME>_SERVICEURL;
+    ```
+
 === "Component.yaml file (v1.0)"
 
     !!! note
@@ -108,6 +118,17 @@ To integrate another service into your application, click the appropriate tab be
           | ConsumerKey    | string     | Consumer key of the Choreo service    | false         | false        |
           | ConsumerSecret | string     | Consumer secret of the Choreo service | false         | true         |
           | TokenURL       | string     | Token URL of the STS                  | false         | false        |
+
+    ### Step 2: Read configurations within the application
+
+    Once you add the connection configuration snippet, you can proceed to read those configurations within your application. The steps to follow depend on the programming language you are using.
+
+    The following is a sample code snippet in NodeJS:
+
+    ``` java
+    const serviceURL = process.env.SVC_URL;
+    ```
+
 
 === "Component-config.yaml file"
 
@@ -159,16 +180,17 @@ To integrate another service into your application, click the appropriate tab be
           | ConsumerSecret | string     | Consumer secret of the Choreo service | false         | true         |
           | TokenURL       | string     | Token URL of the STS                  | false         | false        |
 
+    ### Step 2: Read configurations within the application
 
-### Step 2: Read configurations within the application
+    Once you add the connection configuration snippet, you can proceed to read those configurations within your application. The steps to follow depend on the programming language you are using.
 
-Once you add the connection configuration snippet, you can proceed to read those configurations within your application. The steps to follow depend on the programming language you are using.
+    The following is a sample code snippet in NodeJS:
 
-The following is a sample code snippet in NodeJS:
+    ``` java
+    const serviceURL = process.env.SVC_URL;
+    ```
 
-``` java
-const serviceURL = process.env.SVC_URL;
-```
+
 
 ### Step 3: Acquire an OAuth 2.0 access token
 

--- a/en/docs/develop-components/sharing-and-reusing/use-a-connection-in-your-service.md
+++ b/en/docs/develop-components/sharing-and-reusing/use-a-connection-in-your-service.md
@@ -12,67 +12,9 @@ You can consume a Choreo-deployed service within another service. Consuming conn
 
 ### Step 1: Add connection configurations
 
-To integrate another service into your application, click the appropriate tab below based on your preferred configuration file version and follow the step-by-step instructions provided:
+To integrate another service into your application, click the appropriate tab below based on your current configuration file version and follow the step-by-step instructions:
 
-=== "Component.yaml file (v1.1)"
-
-    1. Copy and paste the snippet from the in-line developer guide into the `component.yaml` file.
-
-        The following is a sample snippet: 
-
-        ``` yaml
-
-        dependencies:
-            connectionReferences:
-            - name: <CONNECTION_NAME>
-              resourceRef: <RESOURCE_IDENTIFIER>
-
-        ```
-
-          | Field            | Description                                                         |
-          |------------------|---------------------------------------------------------------------|
-          | name             | The name given to the connection.                                   |
-          | resourceRef      | A unique, readable identifier of the service being connected to.    |
-
-
-    2. If you've previously added a `connectionReferences` section under `dependencies`, append this as another item under `connectionReferences`. Upon deploying the component, Choreo automatically creates a subscription if applicable and the necessary configurations to establish the connection will be injected into the Choreo-defined environment variables.
-      
-          The following table details the Choreo-defined environment variables:
-
-          | Configuration Key       | Choreo-Defined Environment Variable Name                      |
-          |-------------------------|---------------------------------------------------------------|
-          | ServiceURL              | CHOREO_<CONNECTION_NAME\>_SERVICEURL                           |
-          | ConsumerKey             | CHOREO_<CONNECTION_NAME\>_CONSUMERKEY                          |
-          | ConsumerSecret          | CHOREO_<CONNECTION_NAME\>_CONSUMERSECRET                       |
-          | TokenURL                | CHOREO_<CONNECTION_NAME\>_TOKENURL                             |
-
-
-          If you'd like to use custom environment variable names instead of the Choreo-defined ones, add the dependency as a service reference under `dependencies` in the same file. For more details, refer to the instructions under the `component.yaml file (v1.0)` tab.
-
-
-          The following table provides details on the configuration keys associated with the connection:
-
-          | Name           |  Type      |  Description                          |Optional       | Sensitive    |
-          |----------------|------------|---------------------------------------|---------------|--------------|
-          | ServiceURL     | string     | Service URL of the Choreo service     | false         | false        |
-          | ConsumerKey    | string     | Consumer key of the Choreo service    | false         | false        |
-          | ConsumerSecret | string     | Consumer secret of the Choreo service | false         | true         |
-          | TokenURL       | string     | Token URL of the STS                  | false         | false        |
-
-    ### Step 2: Read configurations within the application
-
-    Once you add the connection configuration snippet, you can proceed to read those configurations within your application. The steps to follow depend on the programming language you are using.
-
-    The following is a sample code snippet in NodeJS:
-
-    ``` java
-    const serviceURL = process.env.CHOREO_<CONNECTION_NAME>_SERVICEURL;
-    ```
-
-=== "Component.yaml file (v1.0)"
-
-    !!! note
-        This `component.yaml v1.0` is a legacy configuration format. For new projects, we recommend using the latest version (v1.1) of `component.yaml` for improved usability and features.
+=== "Component.yaml file"
   
     1. Copy and paste the snippet from the in-line developer guide into the `component.yaml` file.
       
@@ -119,7 +61,7 @@ To integrate another service into your application, click the appropriate tab be
           | ConsumerSecret | string     | Consumer secret of the Choreo service | false         | true         |
           | TokenURL       | string     | Token URL of the STS                  | false         | false        |
 
-    ### Step 2: Read configurations within the application
+    <h3> Step 2: Read configurations within the application </h3>
 
     Once you add the connection configuration snippet, you can proceed to read those configurations within your application. The steps to follow depend on the programming language you are using.
 
@@ -133,7 +75,7 @@ To integrate another service into your application, click the appropriate tab be
 === "Component-config.yaml file"
 
     !!! note
-        This `component-config.yaml` is a legacy configuration format. For new projects, we recommend using the latest version (v1.1) of `component.yaml` for improved usability and features.
+        This `component-config.yaml` is a legacy configuration format. For new projects, we recommend using `component.yaml` for improved usability and features.
 
     1. Copy and paste the snippet from the in-line developer guide into the `component-config` file under the `spec` section.
 

--- a/en/docs/develop-components/sharing-and-reusing/use-a-connection-in-your-service.md
+++ b/en/docs/develop-components/sharing-and-reusing/use-a-connection-in-your-service.md
@@ -12,52 +12,152 @@ You can consume a Choreo-deployed service within another service. Consuming conn
 
 ### Step 1: Add connection configurations
 
-To integrate another service into your application, follow the steps below:
+To integrate another service into your application, click the appropriate tab below based on your preferred configuration file version and follow the step-by-step instructions provided:
 
-1. Copy and paste the snippet from the in-line developer guide into the `component-config` file under the `spec` section.
+=== "Component.yaml file (v1.1)"
 
-    The following is a sample snippet:
+    1. Copy and paste the snippet from the in-line developer guide into the `component.yaml` file.
 
-    ``` yaml
+        The following is a sample snippet: 
 
-    outbound:
-        serviceReferences:
-        - name: <SERVICE_NAME>
-          connectionConfig: <CONNECTION_ID>
-          env:
-          - from: ServiceURL
-            to: <YOUR_ENV_VARIABLE_NAME_HERE>
-          - from: ConsumerKey
-            to: <YOUR_ENV_VARIABLE_NAME_HERE>
-          - from: ConsumerSecret
-            to: <YOUR_ENV_VARIABLE_NAME_HERE>
-          - from: TokenURL
-            to: <YOUR_ENV_VARIABLE_NAME_HERE>
+        ``` yaml
 
-    ```
+        dependencies:
+            connectionReferences:
+            - name: <CONNECTION_NAME>
+              resourceRef: <RESOURCE_IDENTIFIER>
 
-      | Field            | Description                                                 |
-      |------------------|-------------------------------------------------------------|
-      | Name             | The name of the service you are connecting to.              |
-      | ConnectionConfig | The unique connection identifier for the connection.        |
-      | env              | The environment variable mapping.                           |
-      | from             | The key of the configuration entry.                         |
-      | to               | The environment variable name to which Choreo will inject the value of the key.|
+        ```
+
+          | Field            | Description                                                         |
+          |------------------|---------------------------------------------------------------------|
+          | name             | The name given to the connection.                                   |
+          | resourceRef      | A unique, readable identifier of the service being connected to.    |
 
 
-2. Replace `<YOUR_ENV_VARIABLE_NAME_HERE>` with an appropriate environment variable name of your choice. If you have previously added an outbound service reference, append this as another item under `serviceReferences`. 
+    2. If you've previously added a `connectionReferences` section under `dependencies`, append this as another item under `connectionReferences`. Upon deploying the component, Choreo automatically creates a subscription if applicable and the necessary configurations to establish the connection will be injected into the Choreo-defined environment variables.
+      
+          The following table details the Choreo-defined environment variables:
 
-      Upon deploying the component, Choreo automatically creates a subscription if applicable and populates the specified environment variables with actual values.
+          | Configuration Key       | Choreo-Defined Environment Variable Name                      |
+          |-------------------------|---------------------------------------------------------------|
+          | ServiceURL              | CHOREO_<CONNECTION_NAME\>_SERVICEURL                           |
+          | ConsumerKey             | CHOREO_<CONNECTION_NAME\>_CONSUMERKEY                          |
+          | ConsumerSecret          | CHOREO_<CONNECTION_NAME\>_CONSUMERSECRET                       |
+          | TokenURL                | CHOREO_<CONNECTION_NAME\>_TOKENURL                             |
 
 
-      The following table provides details on the configuration keys associated with the connection:
+          If you'd like to use custom environment variable names instead of the Choreo-defined ones, add the dependency as a service reference under `dependencies` in the same file. For more details, refer to the instructions under the `component.yaml file (v1.0)` tab.
 
-      | Name           |  Type      |  Description                          |Optional       | Sensitive    |
-      |----------------|------------|---------------------------------------|---------------|--------------|
-      | ServiceURL     | string     | Service URL of the Choreo service     | false         | false        |
-      | ConsumerKey    | string     | Consumer key of the Choreo service    | false         | false        |
-      | ConsumerSecret | string     | Consumer secret of the Choreo service | false         | true         |
-      | TokenURL       | string     | Token URL of the STS                  | false         | false        |
+
+          The following table provides details on the configuration keys associated with the connection:
+
+          | Name           |  Type      |  Description                          |Optional       | Sensitive    |
+          |----------------|------------|---------------------------------------|---------------|--------------|
+          | ServiceURL     | string     | Service URL of the Choreo service     | false         | false        |
+          | ConsumerKey    | string     | Consumer key of the Choreo service    | false         | false        |
+          | ConsumerSecret | string     | Consumer secret of the Choreo service | false         | true         |
+          | TokenURL       | string     | Token URL of the STS                  | false         | false        |
+
+=== "Component.yaml file (v1.0)"
+
+    !!! note
+        This `component.yaml v1.0` is a legacy configuration format. For new projects, we recommend using the latest version (v1.1) of `component.yaml` for improved usability and features.
+  
+    1. Copy and paste the snippet from the in-line developer guide into the `component.yaml` file.
+      
+        The following is a sample snippet:
+
+        ``` yaml
+
+        dependencies:
+            serviceReferences:
+            - name: <SERVICE_NAME>
+              connectionConfig: <CONNECTION_ID>
+              env:
+              - from: ServiceURL
+                to: <YOUR_ENV_VARIABLE_NAME_HERE>
+              - from: ConsumerKey
+                to: <YOUR_ENV_VARIABLE_NAME_HERE>
+              - from: ConsumerSecret
+                to: <YOUR_ENV_VARIABLE_NAME_HERE>
+              - from: TokenURL
+                to: <YOUR_ENV_VARIABLE_NAME_HERE>
+
+        ```
+
+          | Field            | Description                                                 |
+          |------------------|-------------------------------------------------------------|
+          | name             | The name of the service you are connecting to.              |
+          | connectionConfig | The unique connection identifier for the connection.        |
+          | env              | The environment variable mapping.                           |
+          | from             | The key of the configuration entry.                         |
+          | to               | The environment variable name to which Choreo will inject the value of the key.|
+
+
+    2. Replace `<YOUR_ENV_VARIABLE_NAME_HERE>` with an appropriate environment variable name of your choice. If you have previously added a service reference section under `dependencies`, append this as another item under `serviceReferences`. 
+
+          Upon deploying the component, Choreo automatically creates a subscription if applicable and populates the specified environment variables with actual values.
+
+
+          The following table provides details on the configuration keys associated with the connection:
+
+          | Name           |  Type      |  Description                          |Optional       | Sensitive    |
+          |----------------|------------|---------------------------------------|---------------|--------------|
+          | ServiceURL     | string     | Service URL of the Choreo service     | false         | false        |
+          | ConsumerKey    | string     | Consumer key of the Choreo service    | false         | false        |
+          | ConsumerSecret | string     | Consumer secret of the Choreo service | false         | true         |
+          | TokenURL       | string     | Token URL of the STS                  | false         | false        |
+
+=== "Component-config.yaml file"
+
+    !!! note
+        This `component-config.yaml` is a legacy configuration format. For new projects, we recommend using the latest version (v1.1) of `component.yaml` for improved usability and features.
+
+    1. Copy and paste the snippet from the in-line developer guide into the `component-config` file under the `spec` section.
+
+        The following is a sample snippet:
+
+        ``` yaml
+
+        outbound:
+            serviceReferences:
+            - name: <SERVICE_NAME>
+              connectionConfig: <CONNECTION_ID>
+              env:
+              - from: ServiceURL
+                to: <YOUR_ENV_VARIABLE_NAME_HERE>
+              - from: ConsumerKey
+                to: <YOUR_ENV_VARIABLE_NAME_HERE>
+              - from: ConsumerSecret
+                to: <YOUR_ENV_VARIABLE_NAME_HERE>
+              - from: TokenURL
+                to: <YOUR_ENV_VARIABLE_NAME_HERE>
+
+        ```
+
+          | Field            | Description                                                 |
+          |------------------|-------------------------------------------------------------|
+          | name             | The name of the service you are connecting to.              |
+          | connectionConfig | The unique connection identifier for the connection.        |
+          | env              | The environment variable mapping.                           |
+          | from             | The key of the configuration entry.                         |
+          | to               | The environment variable name to which Choreo will inject the value of the key.|
+
+
+    2. Replace `<YOUR_ENV_VARIABLE_NAME_HERE>` with an appropriate environment variable name of your choice. If you have previously added an outbound service reference, append this as another item under `serviceReferences`. 
+
+          Upon deploying the component, Choreo automatically creates a subscription if applicable and populates the specified environment variables with actual values.
+
+
+          The following table provides details on the configuration keys associated with the connection:
+
+          | Name           |  Type      |  Description                          |Optional       | Sensitive    |
+          |----------------|------------|---------------------------------------|---------------|--------------|
+          | ServiceURL     | string     | Service URL of the Choreo service     | false         | false        |
+          | ConsumerKey    | string     | Consumer key of the Choreo service    | false         | false        |
+          | ConsumerSecret | string     | Consumer secret of the Choreo service | false         | true         |
+          | TokenURL       | string     | Token URL of the STS                  | false         | false        |
 
 
 ### Step 2: Read configurations within the application


### PR DESCRIPTION
## Purpose
With the implementation of newer `component.yaml` configuration descriptor files, the instructions under [`Step 1: Add connection configurations`](https://wso2.com/choreo/docs/develop-components/sharing-and-reusing/use-a-connection-in-your-service/#step-1-add-connection-configurations) in the `Use a Connection in Your Service` page has to be updated. So we need to $subject.

Resolves: https://github.com/wso2-enterprise/choreo/issues/31907

## Goals
- The instructions specific for each configuration file type will be accessible in the same page.

## Approach
- A tab view is used to include the instructions for each three types of config files. This is convenient since only the instructions in `Step 1` section varies with the config file type.


## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs
