### PR TITLE
Add required guides for component.yaml v1.1 config file

### DIFF
--- a/en/docs/develop-components/manage-component-source-configurations.md
+++ b/en/docs/develop-components/manage-component-source-configurations.md
@@ -26,95 +26,182 @@ The source configuration file must be committed to your repository within the `.
 
 **Sample `component.yaml` file content**:
 
-``` yaml
-# +required The configuration file schema version
-schemaVersion: 1.0
+=== "Version 1.1"
 
-# +optional Incoming connection details for the component
-endpoints:
-  # +required Unique name for the endpoint.
-  # This name will be used when generating the managed API
-  - name: greeter-sample
-    # +optional Display name for the endpoint.
-    displayName: Go Greeter Sample
-    # +required Service section has the user service endpoint details
-    service:
-      # +optional Context (base path) of the API that gets exposed via the endpoint.
-      basePath: /greeting-service
-      # +required Numeric port value that gets exposed via the endpoint
-      port: 9090
-    # +required Type of traffic that the endpoint is accepting.
-    # Allowed values: REST, GraphQL, GRPC, TCP, UDP.
-    type: REST
-    # +optional Network level visibilities of the endpoint.
-    # Accepted values: Project|Organization|Public(Default).
-    networkVisibilities: 
-      - Public
-      - Organization
-    # +optional Path to the schema definition file. Defaults to wild card route if not provided
-    # This is only applicable to REST endpoint types.
-    # The path should be relative to the docker context.
-    schemaFilePath: openapi.yaml
-  
-  # +optional Outgoing connection details for the component.
-  dependencies:
-    # +optional Defines the service references from the Internal Marketplace.
-    serviceReferences:
-      # +required Name of the service reference.
-      - name: choreo:///apifirst/mttm/mmvhxd/ad088/v1.0/PUBLIC
-        # +required Name of the connection instance.
-        connectionConfig: 19d2648b-d29c-4452-afdd-1b9311e81412
-        # +required Environment variables injected into the component for connection configuration.
-        env:
-          # +required Key name of the connection configuration.
-          - from: ServiceURL
-            # +required Environment variable injected into the container.
-            to: SERVICE_URL
-```
+    ``` yaml
+    # +required The configuration file schema version
+    schemaVersion: 1.1
 
-The descriptor-based approach of the `component.yaml` file simplifies and streamlines endpoint and connection configuration management. The use of versioned schemas ensures backward compatibility, providing a seamless transition with future updates.
+    # +optional Incoming connection details for the component
+    endpoints:
+      # +required Unique name for the endpoint.
+      # This name will be used when generating the managed API
+      - name: greeter-sample
+        # +optional Display name for the endpoint.
+        displayName: Go Greeter Sample
+        # +required Service section has the user service endpoint details
+        service:
+          # +optional Context (base path) of the API that gets exposed via the endpoint.
+          basePath: /greeting-service
+          # +required Numeric port value that gets exposed via the endpoint
+          port: 9090
+        # +required Type of traffic that the endpoint is accepting.
+        # Allowed values: REST, GraphQL, GRPC, TCP, UDP.
+        type: REST
+        # +optional Network level visibilities of the endpoint.
+        # Accepted values: Project|Organization|Public(Default).
+        networkVisibilities: 
+          - Public
+          - Organization
+        # +optional Path to the schema definition file. Defaults to wild card route if not provided
+        # This is only applicable to REST endpoint types.
+        # The path should be relative to the docker context.
+        schemaFilePath: openapi.yaml
+      
+      # +optional Outgoing connection details for the component.
+      dependencies:
+        # +optional Defines the connection references from the Internal Marketplace.
+        connectionReferences:
+          # +required Name of the connection.
+          - name: hr-connection
+            # +required Name of the connection instance.
+            resourceRef: service:/HRProject/UserComponent/v1/ad088/PUBLIC
 
-You can define the following root-level configurations via the `component.yaml` file:
+    ```
 
-| Configuration        | Required     | Description                                                              |
-|----------------------|--------------|--------------------------------------------------------------------------|
-| **schemaVersion**    | Required     | The version of the `component.yaml` file. Defaults to the latest version.|
-| **endpoints**        | Optional     | The list of endpoint configurations.                                     |
-| **dependencies**     | Optional     | The list of dependency configurations.                                   |
+    The descriptor-based approach of the `component.yaml` file simplifies and streamlines endpoint and connection configuration management. The use of versioned schemas ensures backward compatibility, providing a seamless transition with future updates.
 
-### Endpoint configurations
-In the `endpoints` section of the `component.yaml` file, you can define multiple service endpoint configurations. Each endpoint must have a unique name and the required fields specified in the schema overview.
+    You can define the following root-level configurations via the `component.yaml` file:
 
-!!! tip "Why have a unique name?"
-       When you define multiple endpoints, the `endpoint.name` is appended to the Choreo-generated URL. A unique name ensures the endpoint is easily recognizable and readable within the URL.
-       
-| Configuration        | Required     | Description                                                                                             |
-|----------------------|--------------|---------------------------------------------------------------------------------------------------------|
-| **name**             | Required     | A unique identifier for the endpoint within the service component. Avoid using excessively long names.  |
-| **displayName**      | Optional     | A display name for the endpoint.                                                                        |
-| **service**          | Required     | Service details for the endpoint.                                                                       |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**.basePath** | Required     | The base path of the API exposed via this endpoint.                        |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**.port**     | Required     | The numeric port value exposed via this endpoint.                          |
-| **type**             | Required     | The type of traffic the endpoint accepts. For example, `REST`, `GraphQL`, `gRPC`, `UDP`, or `TCP`.|
-| **networkVisibilities** | Required | The network-level visibility of the endpoint. For example, project, organization, or public.                    |
-| **schemaFilePath** | Required | The file path to the swagger definition file. Defaults to the wildcard route if not specified. This field should be a relative path to the project path when using **Java**, **Python**, **NodeJS**, **Go**, **PHP**, **Ruby**, or **WSO2 MI** buildpacks. For REST endpoint types, when using the **Ballerina** or **Dockerfile** buildpack, the path should be relative to the component root or Docker context. |
+    | Configuration        | Required     | Description                                                              |
+    |----------------------|--------------|--------------------------------------------------------------------------|
+    | **schemaVersion**    | Required     | The version of the `component.yaml` file. Defaults to the latest version.|
+    | **endpoints**        | Optional     | The list of endpoint configurations.                                     |
+    | **dependencies**     | Optional     | The list of dependency configurations.                                   |
 
-### Dependency configurations
+    ### Endpoint configurations
+    In the `endpoints` section of the `component.yaml` file, you can define multiple service endpoint configurations. Each endpoint must have a unique name and the required fields specified in the schema overview.
 
-In the `dependencies` section of the `component.yaml` file, you can define multiple service connection configurations under `dependencies.serviceReferences`. You can use the service references generated in the Internal Marketplace when creating a service connection. For instructions on copying [connection configurations](https://wso2.com/choreo/docs/develop-components/sharing-and-reusing/use-a-connection-in-your-service/), see the in-line developer guide displayed during connection creation.
+    !!! tip "Why have a unique name?"
+          When you define multiple endpoints, the `endpoint.name` is appended to the Choreo-generated URL. A unique name ensures the endpoint is easily recognizable and readable within the URL.
+          
+    | Configuration        | Required     | Description                                                                                             |
+    |----------------------|--------------|---------------------------------------------------------------------------------------------------------|
+    | **name**             | Required     | A unique identifier for the endpoint within the service component. Avoid using excessively long names.  |
+    | **displayName**      | Optional     | A display name for the endpoint.                                                                        |
+    | **service**          | Required     | Service details for the endpoint.                                                                       |
+    | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**.basePath** | Required     | The base path of the API exposed via this endpoint.                        |
+    | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**.port**     | Required     | The numeric port value exposed via this endpoint.                          |
+    | **type**             | Required     | The type of traffic the endpoint accepts. For example, `REST`, `GraphQL`, `gRPC`, `UDP`, or `TCP`.|
+    | **networkVisibilities** | Required | The network-level visibility of the endpoint. For example, project, organization, or public.                    |
+    | **schemaFilePath** | Required | The file path to the swagger definition file. Defaults to the wildcard route if not specified. This field should be a relative path to the project path when using **Java**, **Python**, **NodeJS**, **Go**, **PHP**, **Ruby**, or **WSO2 MI** buildpacks. For REST endpoint types, when using the **Ballerina** or **Dockerfile** buildpack, the path should be relative to the component root or Docker context. |
 
-You must include the following configurations in the `dependencies.serviceReferences` schema:
+    ### Dependency configurations
 
-| Configuration        | Required     | Description                                                                      |
-|----------------------|--------------|----------------------------------------------------------------------------------|
-| **name**             | Required     | A unique name for the service reference.                                         |
-| **connectionConfig** | Required     | A unique name for the connection instance.                                       |
-| **env**              | Required     | The list of environment variable mappings to inject into the container.  |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**.from**         | Required     | The key name of the connection configuration.                           |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**.to**           | Required     | The environment variable to inject into the container.                  |
+    In the `dependencies` section of the `component.yaml` file, you can define multiple connection configurations under `dependencies.connectionReferences`. You can use the connection reference generated in the in-line developer guide when creating a connection. For instructions on copying [connection configurations](https://wso2.com/choreo/docs/develop-components/sharing-and-reusing/use-a-connection-in-your-service/), see the in-line developer guide displayed during connection creation.
 
-!!! note
-    Choreo automatically generates connection configurations when you create a connection within the Internal Marketplace. The properties such as **name**, **connectionConfig**, and **env.from** are automatically generated. However, you must manually set the **env.to** value.
+    You must include the following configurations in the `dependencies.connectionReferences` schema:
+
+    | Configuration        | Required     | Description                                                                      |
+    |----------------------|--------------|----------------------------------------------------------------------------------|
+    | **name**             | Required     | The name given to the connection.                                                |
+    | **resourceRef**      | Required     | A unique, readable identifier of the service being connected to.                 |
+
+
+    !!! note
+        Choreo automatically generates connection configurations when you create a connection. The properties such as **name**, **resourceRef**,  are automatically generated. The necessary configurations to establish the connection will be injected into Choreo-defined environment variables.
+
+=== "Version 1.0"
+
+    ``` yaml
+    # +required The configuration file schema version
+    schemaVersion: 1.0
+
+    # +optional Incoming connection details for the component
+    endpoints:
+      # +required Unique name for the endpoint.
+      # This name will be used when generating the managed API
+      - name: greeter-sample
+        # +optional Display name for the endpoint.
+        displayName: Go Greeter Sample
+        # +required Service section has the user service endpoint details
+        service:
+          # +optional Context (base path) of the API that gets exposed via the endpoint.
+          basePath: /greeting-service
+          # +required Numeric port value that gets exposed via the endpoint
+          port: 9090
+        # +required Type of traffic that the endpoint is accepting.
+        # Allowed values: REST, GraphQL, GRPC, TCP, UDP.
+        type: REST
+        # +optional Network level visibilities of the endpoint.
+        # Accepted values: Project|Organization|Public(Default).
+        networkVisibilities: 
+          - Public
+          - Organization
+        # +optional Path to the schema definition file. Defaults to wild card route if not provided
+        # This is only applicable to REST endpoint types.
+        # The path should be relative to the docker context.
+        schemaFilePath: openapi.yaml
+      
+      # +optional Outgoing connection details for the component.
+      dependencies:
+        # +optional Defines the service references from the Internal Marketplace.
+        serviceReferences:
+          # +required Name of the service reference.
+          - name: choreo:///apifirst/mttm/mmvhxd/ad088/v1.0/PUBLIC
+            # +required Name of the connection instance.
+            connectionConfig: 19d2648b-d29c-4452-afdd-1b9311e81412
+            # +required Environment variables injected into the component for connection configuration.
+            env:
+              # +required Key name of the connection configuration.
+              - from: ServiceURL
+                # +required Environment variable injected into the container.
+                to: SERVICE_URL
+    ```
+
+    The descriptor-based approach of the `component.yaml` file simplifies and streamlines endpoint and connection configuration management. The use of versioned schemas ensures backward compatibility, providing a seamless transition with future updates.
+
+    You can define the following root-level configurations via the `component.yaml` file:
+
+    | Configuration        | Required     | Description                                                              |
+    |----------------------|--------------|--------------------------------------------------------------------------|
+    | **schemaVersion**    | Required     | The version of the `component.yaml` file. Defaults to the latest version.|
+    | **endpoints**        | Optional     | The list of endpoint configurations.                                     |
+    | **dependencies**     | Optional     | The list of dependency configurations.                                   |
+
+    <h3> Endpoint configurations </h3>
+    In the `endpoints` section of the `component.yaml` file, you can define multiple service endpoint configurations. Each endpoint must have a unique name and the required fields specified in the schema overview.
+
+    !!! tip "Why have a unique name?"
+          When you define multiple endpoints, the `endpoint.name` is appended to the Choreo-generated URL. A unique name ensures the endpoint is easily recognizable and readable within the URL.
+          
+    | Configuration        | Required     | Description                                                                                             |
+    |----------------------|--------------|---------------------------------------------------------------------------------------------------------|
+    | **name**             | Required     | A unique identifier for the endpoint within the service component. Avoid using excessively long names.  |
+    | **displayName**      | Optional     | A display name for the endpoint.                                                                        |
+    | **service**          | Required     | Service details for the endpoint.                                                                       |
+    | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**.basePath** | Required     | The base path of the API exposed via this endpoint.                        |
+    | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**.port**     | Required     | The numeric port value exposed via this endpoint.                          |
+    | **type**             | Required     | The type of traffic the endpoint accepts. For example, `REST`, `GraphQL`, `gRPC`, `UDP`, or `TCP`.|
+    | **networkVisibilities** | Required | The network-level visibility of the endpoint. For example, project, organization, or public.                    |
+    | **schemaFilePath** | Required | The file path to the swagger definition file. Defaults to the wildcard route if not specified. This field should be a relative path to the project path when using **Java**, **Python**, **NodeJS**, **Go**, **PHP**, **Ruby**, or **WSO2 MI** buildpacks. For REST endpoint types, when using the **Ballerina** or **Dockerfile** buildpack, the path should be relative to the component root or Docker context. |
+
+    <h3> Dependency configurations </h3>
+
+    In the `dependencies` section of the `component.yaml` file, you can define multiple service connection configurations under `dependencies.serviceReferences`. You can use the service references generated in the in-line developer guide when creating a service connection. For instructions on copying [connection configurations](https://wso2.com/choreo/docs/develop-components/sharing-and-reusing/use-a-connection-in-your-service/), see the in-line developer guide displayed during connection creation.
+
+    You must include the following configurations in the `dependencies.serviceReferences` schema:
+
+    | Configuration        | Required     | Description                                                                      |
+    |----------------------|--------------|----------------------------------------------------------------------------------|
+    | **name**             | Required     | A unique name for the service reference.                                         |
+    | **connectionConfig** | Required     | A unique name for the connection instance.                                       |
+    | **env**              | Required     | The list of environment variable mappings to inject into the container.  |
+    | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**.from**         | Required     | The key name of the connection configuration.                           |
+    | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**.to**           | Required     | The environment variable to inject into the container.                  |
+
+    !!! note
+        Choreo automatically generates connection configurations when you create a connection. The properties such as **name**, **connectionConfig**, and **env.from** are automatically generated. However, you must manually set the **env.to** value.
 
 ## Overview of the `component-config.yaml` file 
 

--- a/en/docs/develop-components/manage-component-source-configurations.md
+++ b/en/docs/develop-components/manage-component-source-configurations.md
@@ -26,6 +26,8 @@ The source configuration file must be committed to your repository within the `.
 
 **Sample `component.yaml` file content**:
 
+Click the respective tab to view the structure for your current configuration file version:
+
 === "Version 1.1"
 
     ``` yaml
@@ -105,11 +107,11 @@ The source configuration file must be committed to your repository within the `.
     | Configuration        | Required     | Description                                                                      |
     |----------------------|--------------|----------------------------------------------------------------------------------|
     | **name**             | Required     | The name given to the connection.                                                |
-    | **resourceRef**      | Required     | A unique, readable identifier of the service being connected to.                 |
+    | **resourceRef**      | Required     | A unique, human-readable identifier for the service you are connecting.          |
 
 
     !!! note
-        Choreo automatically generates connection configurations when you create a connection. The properties such as **name**, **resourceRef**,  are automatically generated. The necessary configurations to establish the connection will be injected into Choreo-defined environment variables.
+        Choreo automatically generates connection configurations when you create a connection. The properties such as **name** and **resourceRef** are automatically generated. The configurations required to establish the connection will be injected into Choreo-defined environment variables.
 
 === "Version 1.0"
 

--- a/en/docs/develop-components/sharing-and-reusing/use-a-connection-in-your-service.md
+++ b/en/docs/develop-components/sharing-and-reusing/use-a-connection-in-your-service.md
@@ -14,7 +14,65 @@ You can consume a Choreo-deployed service within another service. Consuming conn
 
 To integrate another service into your application, click the appropriate tab below based on your current configuration file and follow the step-by-step instructions:
 
-=== "Component.yaml file"
+=== "Component.yaml file (v1.1)"
+
+    1. Copy and paste the snippet from the in-line developer guide into the `component.yaml` file.
+
+        The following is a sample snippet: 
+
+        ``` yaml
+
+        dependencies:
+            connectionReferences:
+            - name: <CONNECTION_NAME>
+              resourceRef: <RESOURCE_IDENTIFIER>
+
+        ```
+
+          | Field            | Description                                                         |
+          |------------------|---------------------------------------------------------------------|
+          | name             | The name given to the connection.                                   |
+          | resourceRef      | A unique, readable identifier of the service being connected to.    |
+
+
+    2. If you've previously added a `connectionReferences` section under `dependencies`, append this as another item under `connectionReferences`. Upon deploying the component, Choreo automatically creates a subscription if applicable and the necessary configurations to establish the connection will be injected into the Choreo-defined environment variables.
+      
+          The following table details the Choreo-defined environment variables:
+
+          | Configuration Key       | Choreo-Defined Environment Variable Name                       |
+          |-------------------------|----------------------------------------------------------------|
+          | ServiceURL              | CHOREO_<CONNECTION_NAME\>_SERVICEURL                           |
+          | ConsumerKey             | CHOREO_<CONNECTION_NAME\>_CONSUMERKEY                          |
+          | ConsumerSecret          | CHOREO_<CONNECTION_NAME\>_CONSUMERSECRET                       |
+          | TokenURL                | CHOREO_<CONNECTION_NAME\>_TOKENURL                             |
+
+
+          If you'd like to use custom environment variable names instead of the Choreo-defined ones, add the dependency as a service reference under `dependencies` in the same file. For more details, refer to the instructions under the `component.yaml file (v1.0)` tab.
+
+
+          The following table provides details on the configuration keys associated with the connection:
+
+          | Name           |  Type      |  Description                          |Optional       | Sensitive    |
+          |----------------|------------|---------------------------------------|---------------|--------------|
+          | ServiceURL     | string     | Service URL of the Choreo service     | false         | false        |
+          | ConsumerKey    | string     | Consumer key of the Choreo service    | false         | false        |
+          | ConsumerSecret | string     | Consumer secret of the Choreo service | false         | true         |
+          | TokenURL       | string     | Token URL of the STS                  | false         | false        |
+
+    ### Step 2: Read configurations within the application
+
+    Once you add the connection configuration snippet, you can proceed to read those configurations within your application. The steps to follow depend on the programming language you are using.
+
+    The following is a sample code snippet in NodeJS:
+
+    ``` java
+    const serviceURL = process.env.CHOREO_<CONNECTION_NAME>_SERVICEURL;
+    ```
+
+=== "Component.yaml file (v1.0)"
+
+    !!! note
+        This `component.yaml v1.0` is a legacy configuration format. For new projects, we recommend using the latest version (v1.1) of `component.yaml` for improved usability and features.
   
     1. Copy and paste the snippet from the in-line developer guide into the `component.yaml` file.
       
@@ -61,7 +119,7 @@ To integrate another service into your application, click the appropriate tab be
           | ConsumerSecret | string     | Consumer secret of the Choreo service | false         | true         |
           | TokenURL       | string     | Token URL of the STS                  | false         | false        |
 
-    ### Step 2: Read configurations within the application
+    <h3> Step 2: Read configurations within the application </h3>
 
     Once you add the connection configuration snippet, you can proceed to read those configurations within your application. The steps to follow depend on the programming language you are using.
 
@@ -75,7 +133,7 @@ To integrate another service into your application, click the appropriate tab be
 === "Component-config.yaml file"
 
     !!! note
-        This `component-config.yaml` is a legacy configuration format. For new projects, we recommend using `component.yaml` for improved usability and features.
+        This `component-config.yaml` is a legacy configuration format. For new projects, we recommend using the latest version (v1.1) of `component.yaml` for improved usability and features.
 
     1. Copy and paste the snippet from the in-line developer guide into the `component-config` file under the `spec` section.
 

--- a/en/docs/develop-components/sharing-and-reusing/use-a-connection-in-your-service.md
+++ b/en/docs/develop-components/sharing-and-reusing/use-a-connection-in-your-service.md
@@ -129,7 +129,6 @@ To integrate another service into your application, click the appropriate tab be
     const serviceURL = process.env.SVC_URL;
     ```
 
-
 === "Component-config.yaml file"
 
     !!! note
@@ -189,8 +188,6 @@ To integrate another service into your application, click the appropriate tab be
     ``` java
     const serviceURL = process.env.SVC_URL;
     ```
-
-
 
 ### Step 3: Acquire an OAuth 2.0 access token
 


### PR DESCRIPTION
## Purpose

With the implementation of newer component.yaml configuration descriptor files, the guides under following sections has to be updated.

- [Use a Connection in Your Service](https://wso2.com/choreo/docs/develop-components/sharing-and-reusing/use-a-connection-in-your-service/#use-a-connection-in-your-service)
- [Manage Component Source Configurations](https://wso2.com/choreo/docs/develop-components/manage-component-source-configurations/#manage-component-source-configurations) 
 
So we need to $subject.

Resolves: https://github.com/wso2-enterprise/choreo/issues/31907

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
- https://github.com/wso2/docs-choreo-dev/pull/1629
