### PR TITLE
Add content on Choreo samples

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -78,6 +78,11 @@ nav:
       - Deploy Your First Service: quick-start-guides/deploy-your-first-service.md
       - Deploy Your First Static Web Application: quick-start-guides/deploy-your-first-static-web-application.md
       - Deploy a Web Application that Consumes a Backend Service: quick-start-guides/deploy-a-web-application-that-consumes-a-backend-service.md
+  - Choreo Samples:
+      - Explore the Samples Collection:
+          - Samples Overview: choreo-samples/samples-overview.md
+          - Quick Deploy a Sample: choreo-samples/quick-deploy-a-sample.md
+      - Explore the Demo Organization: choreo-samples/explore-the-demo-organization.md
   - Tutorials:
       - Expose a Service as a Managed API: tutorials/expose-a-service-as-a-managed-api.md
       - Secure an API with Role-Based Access Control: tutorials/secure-an-api-with-role-based-access-control.md

--- a/en/theme/material/templates/home-page-2.html
+++ b/en/theme/material/templates/home-page-2.html
@@ -330,7 +330,44 @@
     <div class="spacer_div" style="width: 2%;"></div>
     <!-- Start of second column--> 
     <div class="md_home_column column">
-      <!-- Second column - 1st card-->
+      
+            <!-- Second column - 1st card-->
+            <div class= "md_home_link_container" >
+              <div class="cIconContainer">
+              <div class="hText">
+                  Choreo Samples
+                </div>
+              <div class="hIcon"> 
+                <svg width="16" height="15" viewBox="0 0 16 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path fill-rule="evenodd" clip-rule="evenodd" d="M8.46562 13.4822C8.56106 13.4749 8.65587 13.4653 8.75 13.4536C11.464 13.1151 13.6151 10.964 13.9536 8.25C13.9653 8.15587 13.9749 8.06106 13.9822 7.96562C13.9871 7.90216 13.991 7.83842 13.9938 7.77441C13.9979 7.68346 14 7.59197 14 7.5C14 4.18629 11.3137 1.5 8 1.5C4.68629 1.5 2 4.18629 2 7.5C2 7.567 2.0011 7.63374 2.00327 7.70021C2.10714 10.8682 4.66684 13.4149 7.84002 13.4979C7.89317 13.4993 7.94649 13.5 8 13.5C8.05732 13.5 8.11444 13.4992 8.17134 13.4976C8.27005 13.4948 8.36816 13.4897 8.46562 13.4822ZM8.53452 11.9686C8.60277 11.989 8.6751 12 8.75 12C10.8211 12 12.5 10.3211 12.5 8.25C12.5 8.1751 12.489 8.10277 12.4686 8.03452C12.376 7.72533 12.0893 7.5 11.75 7.5C11.3358 7.5 11 7.83579 11 8.25C11 9.49264 9.99264 10.5 8.75 10.5C8.33579 10.5 8 10.8358 8 11.25C8 11.5893 8.22533 11.876 8.53452 11.9686ZM9.5 14.85C9.01534 14.9484 8.5137 15 8 15C7.4863 15 6.98466 14.9484 6.5 14.85C5.97829 14.7441 5.47625 14.584 5 14.3759V18.75C5 19.1642 5.33579 19.5 5.75 19.5H10.25C10.6642 19.5 11 19.1642 11 18.75V14.3759C10.9732 14.3876 10.9463 14.3992 10.9193 14.4106C10.4672 14.6019 9.99234 14.75 9.5 14.85ZM12.5 13.5005C14.3217 12.1322 15.5 9.95373 15.5 7.5C15.5 3.35786 12.1421 0 8 0C3.85786 0 0.5 3.35786 0.5 7.5C0.5 9.82995 1.56245 11.9118 3.2293 13.2874C3.31785 13.3604 3.40811 13.4315 3.5 13.5005V18.75C3.5 19.9926 4.50736 21 5.75 21V21.75C5.75 22.9926 6.75736 24 8 24C9.24264 24 10.25 22.9926 10.25 21.75V21C11.4926 21 12.5 19.9926 12.5 18.75V13.5005ZM7.25 21.75C7.25 22.1642 7.58579 22.5 8 22.5C8.41421 22.5 8.75 22.1642 8.75 21.75V21H7.25V21.75Z" fill="black"/>
+                  </svg>                                                 
+              </div>
+              </div>
+              <div class="cContentContainer">
+                <div class="iconTextcontainer">
+                <div class="cIcon">
+                  <svg width="11" height="20" viewBox="0 -3 11 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M5.95801 0.0537109L10.748 4.83643L5.95801 9.62646L5.21094 8.88672L8.76318 5.36377L0.0473633 5.34912V4.33105L8.74854 4.31641L5.21094 0.793457L5.95801 0.0537109Z" fill="#5567D5"/>
+                    </svg>                                          
+                </div>
+                <div class="cText">
+                  <a href="choreo-samples/quick-deploy-a-sample/"> Quick Deploy a Sample</a> 
+                </div>
+                </div>
+                <div class="iconTextcontainer last_in_card">
+                <div class="cIcon">
+                  <svg width="11" height="20" viewBox="0 -3 11 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M5.95801 0.0537109L10.748 4.83643L5.95801 9.62646L5.21094 8.88672L8.76318 5.36377L0.0473633 5.34912V4.33105L8.74854 4.31641L5.21094 0.793457L5.95801 0.0537109Z" fill="#5567D5"/>
+                    </svg>                                            
+                </div>
+                <div class="cText">
+                  <a href="choreo-samples/explore-the-demo-organization/"> Explore the Demo Organization</a>
+                </div>
+                </div>
+              </div>
+          </div>
+      <!-- Second column - 2nd card-->
+      <div class="spacer_div_verticle first_column_space"></div> 
       <div class= "md_home_link_container" >
         <div class="cIconContainer">
         <div class="hText">Develop Components </div>
@@ -519,8 +556,8 @@
                   <div class="cText">
                     <a href="administer/configure-a-custom-domain-for-apis/">Administer</a>
                   </div>
-                </div>
-                <div class="iconTextcontainer"> 
+                  </div>
+                  <div class="iconTextcontainer last_in_card"> 
                     <div class="cIcon">
                       <svg width="11" height="20" viewBox="0 -3 11 10" fill="none" xmlns="http://www.w3.org/2000/svg">
                         <path d="M5.95801 0.0537109L10.748 4.83643L5.95801 9.62646L5.21094 8.88672L8.76318 5.36377L0.0473633 5.34912V4.33105L8.74854 4.31641L5.21094 0.793457L5.95801 0.0537109Z" fill="#5567D5"/>
@@ -529,17 +566,7 @@
                     <div class="cText">
                       <a href="manage-databases-and-caches/choreo-managed-databases-and-caches/">Databases and Caches</a>
                     </div>
-                </div>
-                <div class="iconTextcontainer last_in_card"> 
-                  <div class="cIcon">
-                    <svg width="11" height="20" viewBox="0 -3 11 10" fill="none" xmlns="http://www.w3.org/2000/svg">
-                      <path d="M5.95801 0.0537109L10.748 4.83643L5.95801 9.62646L5.21094 8.88672L8.76318 5.36377L0.0473633 5.34912V4.33105L8.74854 4.31641L5.21094 0.793457L5.95801 0.0537109Z" fill="#5567D5"/>
-                      </svg>                                            
                   </div>
-                  <div class="cText">
-                    <a href="manage-message-brokers/choreo-managed-message-brokers/">Message Brokers</a>
-                  </div>
-                </div>
           </div>
       </div>    
        <!--end of column 3 - card 1 -->


### PR DESCRIPTION
## Purpose
Add topics on Choreo samples to the left navigation and landing page.

The content was added via https://github.com/wso2/docs-choreo-dev/pull/1606, but was hidden from the left nav and landing page until approval was obtained to push to prod 
