### PR TITLE
Update note block to clarify the use of custom env-var names

### DIFF
--- a/en/docs/develop-components/manage-component-source-configurations.md
+++ b/en/docs/develop-components/manage-component-source-configurations.md
@@ -66,7 +66,7 @@ Click the respective tab to view the structure for your current configuration fi
         connectionReferences:
           # +required Name of the connection.
           - name: hr-connection
-            # +required Name of the connection instance.
+            # +required service identifer of the dependent component.
             resourceRef: service:/HRProject/UserComponent/v1/ad088/PUBLIC
 
     ```
@@ -113,6 +113,8 @@ Click the respective tab to view the structure for your current configuration fi
     !!! note
         Choreo automatically generates connection configurations when you create a connection. The properties such as **name** and **resourceRef** are automatically generated. The configurations required to establish the connection will be injected into Choreo-defined environment variables.
 
+        If you'd like to use custom environment variable names instead of the default Choreo-defined ones, you can add the dependency in the format of a `serviceReference` under `dependencies` in the same `component.yaml v1.1` due to its backward-compatibility. Simply copy the configuration from `component.yaml v1.0` tab and paste it under `dependencies` in your `component.yaml v1.1` configuration file.
+
 === "Version 1.0"
 
     ``` yaml
@@ -150,7 +152,7 @@ Click the respective tab to view the structure for your current configuration fi
         # +optional Defines the service references from the Internal Marketplace.
         serviceReferences:
           # +required Name of the service reference.
-          - name: choreo:///apifirst/mttm/mmvhxd/ad088/v1.0/PUBLIC
+          - name: choreo:///apifirst/HRProject/UserComponent/ad088/v1/PUBLIC
             # +required Name of the connection instance.
             connectionConfig: 19d2648b-d29c-4452-afdd-1b9311e81412
             # +required Environment variables injected into the component for connection configuration.

--- a/en/docs/develop-components/manage-component-source-configurations.md
+++ b/en/docs/develop-components/manage-component-source-configurations.md
@@ -113,7 +113,7 @@ Click the respective tab to view the structure for your current configuration fi
     !!! note
         Choreo automatically generates connection configurations when you create a connection. The properties such as **name** and **resourceRef** are automatically generated. The configurations required to establish the connection will be injected into Choreo-defined environment variables.
 
-        If you'd like to use custom environment variable names instead of the default Choreo-defined ones, you can add the dependency in the format of a `serviceReference` under `dependencies` in the same `component.yaml v1.1` due to its backward-compatibility. Simply copy the configuration from `component.yaml v1.0` tab and paste it under `dependencies` in your `component.yaml v1.1` configuration file.
+        To use custom environment variable names instead of Choreo's default ones, add the dependency as a `serviceReference` in your `component.yaml v1.1` file. You can copy the `serviceReference` section from the `component.yaml v1.0` tab and paste it under `dependencies` in your `component.yaml v1.1` file, which maintains backward compatibility with the v1.0 format.
 
 === "Version 1.0"
 


### PR DESCRIPTION
## Purpose
$subject

## Goals
- To clarify the procedure on using custom environment variable names
- To list the same dependency in both connectionReference and serviceReference formats for consistency in v1.1 and v1.0 tabs

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs
