### PR TITLE
Add configuration group documentation for dev-ops section

### DIFF
--- a/en/docs/devops-and-ci-cd/manage-configuration-groups.md
+++ b/en/docs/devops-and-ci-cd/manage-configuration-groups.md
@@ -1,19 +1,16 @@
 
 # Manage Configuration Groups
 
-**Configuration groups** are collections of key-value pairs that can be linked to any component within the organization, enabling centralized configuration management.
+Choreo allows you to create Configuration Groups to efficiently manage reusable configurations across components within your organization. A Configuration Group is a collection of key-value pairs, where values can be defined for multiple environments. This feature ensures consistency and simplifies the management of configurations across environments.
 
-Configuration values can be maintained for a set of environments. During deployment, a configuration group can be linked to inject its keys as environment variables or file mounts. Choreo manages the secrets and configurations, ensuring they are applied correctly during deployment and promotion.
+Configuration groups can be defined at organization level and link to components at deployment time. Once linked, Choreo automatically resolves and mounts the configurations based to environments on deployment. You can either link a configuration group to inject the configurations as environment variables or file mounts.
 
 !!!important
-    All the values provided for configuration groups are encrypted and stored in the environment specific key vaults.
+    - All configuration group values are encrypted and stored in environment-specific key vaults.
+    - Management of configuration groups is restricted to users with Choreo Admin, DevOps, and Platform Engineer roles.
+    - Developers can discover configuration groups available within the organization via the **Choreo Internal Marketplace**.
 
-## Create a new configuration group
-
-#### Prerequisites
-
-- To create and manage configuration groups, you must have the `CONFIGURATION-GROUP-MANAGEMENT` permission. By default, `CONFIGURATION-GROUP-MANAGEMENT` permission is granted to Admin and Choreo DevOps roles.
-
+## Create a configuration group
 
 To create a new configuration group, follow the steps given below:
 
@@ -25,40 +22,44 @@ To create a new configuration group, follow the steps given below:
     - **Description**: A description for the configuration group (Optional).
     - **Define Keys**: Define the keys for the configuration group.
 
-        !!!note
-            Configuration keys are used to uniquely identify the values of the configuration group. You can map the keys defined here to environment variables or file names at deployment time as required. Keys are unique within a configuration group.
+        - Configuration keys uniquely identify values in a configuration group. You can map these keys to environment variables or file mounts during deployment. Each key must be unique within the group.
 
     - **Assign Values**: Define values by environment for the keys defined.
-  
-        !!!note
-            By default, critical and non-critical environments are grouped together allowing you to manage configuration smoothly. You can remove and manage configuration values for environments separately based on your requirements.
 
-    - **Create**: Click **Create** to create the configuration group. Now you can link this configuration group to any component within the organization.
+        - By default, all the environments are grouped together allowing you to manage configuration smoothly. You can separate and manage configuration values for each environment as needed.
+
+    - **Create**: Click **Create** to create the configuration group. 
+    
+4. Now you can link this configuration group to any component within the organization.
+
+!!!note
+    - Configuration groups created will be listed in the **Choreo Internal Marketplace**, improving visibility and discoverability for developers.
+    - All configuration groups will also be listed in the component deployment drawers, allowing developers to easily link them during deployment.
 
 ## Link and use configuration groups
 
 The configuration groups created at organization level can be linked to any component within the organization. A configuration group can be linked as **Environment Variables** or **File Mounts** at deployment time.
 
-Linking a configuration group will inject the values defined in the configuration group using the keys defined as the environment variable name or the file name at deployment time. You can use a custom environment variable name or file name instead of the default by mapping to the configuration group key.
+Linking a configuration group will inject the values defined in the group during deployment. The values are mapped to environment variable names or file names based on the keys defined in the configuration group. If needed, you can customize the environment variable name or file name by updating the mapping at deployment.
 
 To link a configuration group to a component, follow the steps given below:
 
-1. Navigate to the component you want to link the configuration group to.
+1. Navigate to the component you want to link the configuration group.
 2. On the **Deploy** page, click **Configure & Deploy**, this will open the configuration and deployment wizard.
-3. Link configuration groups as **Environment Variables** or **File Mounts** as required.
+3. In the wizard, link the configuration groups as **Environment Variables** or **File Mounts**, based on your requirements.
 
     === "Environment Variables"
 
-        - Select the configuration group you want to link to the component.
+        - Choose the configuration group you want to link to the component.
         - Click **Link** to link the configuration group to the component.
 
     === "File Mounts"
 
-        - Select the configuration group you want to link to the component.
+        - Choose the configuration group you want to link to the component.
         - Specify the **Mount Path** to mount the configuration files.
             
             !!!note
-                All the configuration within the configuration group will be mounted to the specified path / directory as files.
+                All configurations within the selected configuration group will be mounted as individual files to the specified mount path/directory.
 
         - Click **Link** to link the configuration group to the component.
 
@@ -70,43 +71,40 @@ To view & edit a configuration group, follow the steps given below:
 
 1. Sign in to the [Choreo Console](https://console.choreo.dev/) and switch to your organization.
 2. In the left navigation menu, click **DevOps** and then click **Configuration Groups**. 
-3. In the **Configuration Groups** list, click on the corresponding record to view the configuration group.
+3. In the **Configuration Groups** list, select the desired configuration group to view.
 
     !!!note
         - Only non-sensitive configuration values are displayed in the view mode.
-        - Updating the configuration group will not impact the current deployment but the changes will be reflected when the component is redeployed.
+        - Updating the configuration group will not affect the current deployment; changes will be applied when the component is redeployed.
 
 ### Edit the configuration group
 
-Configuration keys defined in the configuration group can be altered and the changes will impact the components using the particular configuration group when redeployed.
+Configuration keys and values within a configuration group can be modified, and these changes will take effect when the components using the configuration group are redeployed.
 
-To edit the configuration group, click **Edit the Configuration Group** and update the required details.
+To edit the configuration group definition, click **Edit the Configuration Group** and make the necessary updates:
 
-- Configuration keys can be added, removed.
-- Configuration group name and description can be updated.
+- Add or remove configuration keys.
+- Update the configuration group's display name and description.
 
-### Edit the configuration values
+To edit the configuration values, click the edit icon in the corresponding set of environments and modify the required details:
 
-Configuration values can be edited in each set of environments separately and the component using the configuration group needs to be redeployed for the changes to reflect.
-
-To edit the configuration values, click the edit icon in the corresponding set of environments and update the required details.
-
-- Configuration values can be updated.
-- Configuration environment can be added or removed from an existing set of environments.
+- Update configuration values.
+- Add a new set of configuration values.
+- Add or remove environments from an existing set.
 
 !!! warning
-    - **Adding a new environment:** All the non-sensitive configuration values will be copied to the new environment but the sensitive values will not be copied. Hence the sensitive values will be cleared from all the environments in the particular set. **A new value needs to be provided for the sensitive values**.
-    - **Removing an environment:** All the configuration values for the environment will be deleted.
+    - **Adding a new environment:** Non-sensitive configuration values will be copied to the new environment, but sensitive values will not be. As a result, sensitive values will be cleared across all environments in the set. **New values must be provided for sensitive configurations.**
+    - **Removing an environment:** All configuration values for the removed environment will be deleted.
 
 ## Delete a configuration group
 
 To delete a configuration group, follow the steps given below:
 
 !!! warning
-    Configuration group deletion is a permanent, non-reversible operation. Ensure that the configuration group is not linked to any component before deleting it.
+    Deleting a configuration group is a permanent, non-reversible action. Ensure that the configuration group is not linked to any component before deleting it.
 
 1. Sign in to the [Choreo Console](https://console.choreo.dev/) and switch to your organization.
 2. In the left navigation menu, click **DevOps** and then click **Configuration Groups**. 
-3. In the **Configuration Groups** list, click the delete icon corresponding to the configuration group you want to delete. This displays a confirmation dialog with details on the impact of deletion.
+3. In the **Configuration Groups** list, click the delete icon next to the configuration group you want to delete. This will display a confirmation dialog with details about the impact of the deletion.
 4. Review the details, then type the configuration group name to confirm the deletion.
 5. Click **Delete**.

--- a/en/docs/devops-and-ci-cd/manage-configuration-groups.md
+++ b/en/docs/devops-and-ci-cd/manage-configuration-groups.md
@@ -1,0 +1,112 @@
+
+# Manage Configuration Groups
+
+**Configuration groups** are collections of key-value pairs that can be linked to any component within the organization, enabling centralized configuration management.
+
+Configuration values can be maintained for a set of environments. During deployment, a configuration group can be linked to inject its keys as environment variables or file mounts. Choreo manages the secrets and configurations, ensuring they are applied correctly during deployment and promotion.
+
+!!!important
+    All the values provided for configuration groups are encrypted and stored in the environment specific key vaults.
+
+## Create a new configuration group
+
+#### Prerequisites
+
+- To create and manage configuration groups, you must have the `CONFIGURATION-GROUP-MANAGEMENT` permission. By default, `CONFIGURATION-GROUP-MANAGEMENT` permission is granted to Admin and Choreo DevOps roles.
+
+
+To create a new configuration group, follow the steps given below:
+
+1. Sign in to the [Choreo Console](https://console.choreo.dev/) and switch to the organization where you want to create a new configuration group. 
+2. In the left navigation menu, click **DevOps** and then click **Configuration Groups**.
+3. On the **Configuration Groups** page, click **Create** and specify the following details to create a new configuration group:
+   
+    - **Name**: A name for the configuration group (Unique within the organization).
+    - **Description**: A description for the configuration group (Optional).
+    - **Define Keys**: Define the keys for the configuration group.
+
+        !!!note
+            Configuration keys are used to uniquely identify the values of the configuration group. You can map the keys defined here to environment variables or file names at deployment time as required. Keys are unique within a configuration group.
+
+    - **Assign Values**: Define values by environment for the keys defined.
+  
+        !!!note
+            By default, critical and non-critical environments are grouped together allowing you to manage configuration smoothly. You can remove and manage configuration values for environments separately based on your requirements.
+
+    - **Create**: Click **Create** to create the configuration group. Now you can link this configuration group to any component within the organization.
+
+## Link and use configuration groups
+
+The configuration groups created at organization level can be linked to any component within the organization. A configuration group can be linked as **Environment Variables** or **File Mounts** at deployment time.
+
+Linking a configuration group will inject the values defined in the configuration group using the keys defined as the environment variable name or the file name at deployment time. You can use a custom environment variable name or file name instead of the default by mapping to the configuration group key.
+
+To link a configuration group to a component, follow the steps given below:
+
+1. Navigate to the component you want to link the configuration group to.
+2. On the **Deploy** page, click **Configure & Deploy**, this will open the configuration and deployment wizard.
+3. Link configuration groups as **Environment Variables** or **File Mounts** as required.
+
+    === "Environment Variables"
+
+        - Select the configuration group you want to link to the component.
+        - Click **Link** to link the configuration group to the component.
+
+    === "File Mounts"
+
+        - Select the configuration group you want to link to the component.
+        - Specify the **Mount Path** to mount the configuration files.
+            
+            !!!note
+                All the configuration within the configuration group will be mounted to the specified path / directory as files.
+
+        - Click **Link** to link the configuration group to the component.
+
+4. Complete the deployment wizard by providing the required details and click **Deploy** to deploy the component with the updated configurations.
+
+## View & edit a configuration group
+
+To view & edit a configuration group, follow the steps given below:
+
+1. Sign in to the [Choreo Console](https://console.choreo.dev/) and switch to your organization.
+2. In the left navigation menu, click **DevOps** and then click **Configuration Groups**. 
+3. In the **Configuration Groups** list, click on the corresponding record to view the configuration group.
+
+    !!!note
+        - Only non-sensitive configuration values are displayed in the view mode.
+        - Updating the configuration group will not impact the current deployment but the changes will be reflected when the component is redeployed.
+
+### Edit the configuration group
+
+Configuration keys defined in the configuration group can be altered and the changes will impact the components using the particular configuration group when redeployed.
+
+To edit the configuration group, click **Edit the Configuration Group** and update the required details.
+
+- Configuration keys can be added, removed.
+- Configuration group name and description can be updated.
+
+### Edit the configuration values
+
+Configuration values can be edited in each set of environments separately and the component using the configuration group needs to be redeployed for the changes to reflect.
+
+To edit the configuration values, click the edit icon in the corresponding set of environments and update the required details.
+
+- Configuration values can be updated.
+- Configuration environment can be added or removed from an existing set of environments.
+
+!!! warning
+    - **Adding a new environment:** All the non-sensitive configuration values will be copied to the new environment but the sensitive values will not be copied. Hence the sensitive values will be cleared from all the environments in the particular set. **A new value needs to be provided for the sensitive values**.
+    - **Removing an environment:** All the configuration values for the environment will be deleted.
+
+## Delete a configuration group
+
+To delete a configuration group, follow the steps given below:
+
+!!! warning
+    Configuration group deletion is a permanent, non-reversible operation. Ensure that the configuration group is not linked to any component before deleting it.
+
+1. Sign in to the [Choreo Console](https://console.choreo.dev/) and switch to your organization.
+2. In the left navigation menu, click **DevOps** and then click **Configuration Groups**. 
+3. In the **Configuration Groups** list, click the delete icon corresponding to the configuration group you want to delete. This displays a confirmation dialog with details on the impact of deletion.
+4. Review the details, then type the configuration group name to confirm the deletion.
+5. Click **Delete**.

--- a/en/docs/devops-and-ci-cd/manage-configuration-groups.md
+++ b/en/docs/devops-and-ci-cd/manage-configuration-groups.md
@@ -3,7 +3,7 @@
 
 Choreo allows you to create Configuration Groups to efficiently manage reusable configurations across components within your organization. A Configuration Group is a collection of key-value pairs, where values can be defined for multiple environments. This feature ensures consistency and simplifies the management of configurations across environments.
 
-Configuration groups can be defined at organization level and link to components at deployment time. Once linked, Choreo automatically resolves and mounts the configurations based to environments on deployment. You can either link a configuration group to inject the configurations as environment variables or file mounts.
+Configuration groups can be defined at organization level and link to components at deployment time. Once linked, Choreo automatically resolves and mounts the configurations to the respective environments on deployment. You can either link a configuration group to inject the configurations as environment variables or file mounts.
 
 !!!important
     - All configuration group values are encrypted and stored in environment-specific key vaults.
@@ -14,7 +14,7 @@ Configuration groups can be defined at organization level and link to components
 
 To create a new configuration group, follow the steps given below:
 
-1. Sign in to the [Choreo Console](https://console.choreo.dev/) and switch to the organization where you want to create a new configuration group. 
+1. In the [Choreo Console](https://console.choreo.dev/), go to the top navigation menu. Click **Organization** and select your organization.
 2. In the left navigation menu, click **DevOps** and then click **Configuration Groups**.
 3. On the **Configuration Groups** page, click **Create** and specify the following details to create a new configuration group:
    
@@ -69,7 +69,7 @@ To link a configuration group to a component, follow the steps given below:
 
 To view & edit a configuration group, follow the steps given below:
 
-1. Sign in to the [Choreo Console](https://console.choreo.dev/) and switch to your organization.
+1. In the [Choreo Console](https://console.choreo.dev/), go to the top navigation menu. Click **Organization** and select your organization.
 2. In the left navigation menu, click **DevOps** and then click **Configuration Groups**. 
 3. In the **Configuration Groups** list, select the desired configuration group to view.
 
@@ -103,7 +103,7 @@ To delete a configuration group, follow the steps given below:
 !!! warning
     Deleting a configuration group is a permanent, non-reversible action. Ensure that the configuration group is not linked to any component before deleting it.
 
-1. Sign in to the [Choreo Console](https://console.choreo.dev/) and switch to your organization.
+1. In the [Choreo Console](https://console.choreo.dev/), go to the top navigation menu. Click **Organization** and select your organization.
 2. In the left navigation menu, click **DevOps** and then click **Configuration Groups**. 
 3. In the **Configuration Groups** list, click the delete icon next to the configuration group you want to delete. This will display a confirmation dialog with details about the impact of the deletion.
 4. Review the details, then type the configuration group name to confirm the deletion.

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -173,6 +173,7 @@ nav:
         - Autoscale Components with Scale-to-Zero: devops-and-ci-cd/autoscale/autoscale-components-with-scale-to-zero.md
       - Configure Storage: devops-and-ci-cd/configure-storage.md
       - Manage Environments: devops-and-ci-cd/manage-environments.md
+      - Manage Configuration Groups: devops-and-ci-cd/manage-configuration-groups.md
       - Manage Continuous Deployment Pipelines: devops-and-ci-cd/manage-continuous-deployment-pipelines.md
       - Configure VPNs on the Choreo Cloud Data Plane: devops-and-ci-cd/configure-vpns-on-the-choreo-cloud-data-plane.md
   - Testing: 


### PR DESCRIPTION
## Purpose
> Adds `configuration group` related documentation under `DevOps` section as `Manage configuration groups`

Related https://github.com/wso2-enterprise/choreo/issues/31908

## Goals
> Introduce the basic concept of configuration groups and guide the user through the creation and config group management flows.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs
