### PR TITLE
Add note about tag-based build triggering for admin users

### DIFF
--- a/en/docs/choreo-concepts/ci-cd.md
+++ b/en/docs/choreo-concepts/ci-cd.md
@@ -37,6 +37,9 @@ Choreo can replicate builds from an identical code version (Git commit). This me
 
 On the **Build** page, click **Build Latest**. If necessary, you have the option to select a particular commit and build an image.
 
+!!! note
+    Admin and Choreo DevOps users can trigger builds using specific tags from the connected Git repository. However, this action bypasses the standard branch-based deployment process and should only be used for critical, time-sensitive scenarios, as it can disrupt deployment track integrity.
+
 If you want to automatically trigger a build with each commit, you can enable **Auto Build on Commit**.
 
 ### Build logs


### PR DESCRIPTION
## Purpose
related to https://github.com/wso2-enterprise/choreo/issues/33442

This pull request includes an update to the `ci-cd.md` documentation to provide additional guidance on triggering builds in critical scenarios.

Documentation update:

* [`en/docs/choreo-concepts/ci-cd.md`](diffhunk://#diff-909bb7b475f57a2e56da6f39baba46e562f6515528a3621c186c26a7f76e1b67R40-R42): Added a note explaining that Admin and Choreo DevOps users can trigger builds by selecting specific tags within the connected repository, bypassing the standard branch-based deployment process. This action should be reserved for critical, time-sensitive scenarios due to potential disruptions to deployment track integrity.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs
