### PR TITLE
Update maximum request payload size in documentation to 50 MB

### DIFF
--- a/en/docs/references/choreo-limitations.md
+++ b/en/docs/references/choreo-limitations.md
@@ -8,7 +8,7 @@ Below are key limitations when working with APIs in Choreo:
 
 |Resource                             |  Limit                                                                                      |
 |-------------------------------------|---------------------------------------------------------------------------------------------|
-| Maximum request payload             |  10 MB                                                                                      |
+| Maximum request payload             |  50 MB                                                                                      |
 | URL size                            |  2 KB                                                                                       |
 | Request header                      | <ul><li>Request Headers total: 40 KB</li><li>Max Single Request header: 10 KB</li></ul>     |
 | Total request duration              | <ul><li>Minimum: 10 seconds</li><li>Default: 1 minute</li><li>Maximum: 5 minutes</li></ul>  |

--- a/en/docs/references/faq.md
+++ b/en/docs/references/faq.md
@@ -33,7 +33,7 @@ You can find information about our support plans, including `free`, `basic`, and
 If you have a log monitoring product or service, such as Azure Monitor, you can use it together with Choreo. Note: The log monitoring tool is not included in the infrastructure cost.
 
 ### Q: What is the maximum request payload size supported by Choreo?
-Choreo allows a maximum request payload size of 10 MB. 
+Choreo allows a maximum request payload size of 50 MB.
 
 ### Q: What source control software does Choreo support?
 Choreo now supports GitHub, Bitbucket and GitLab. 


### PR DESCRIPTION
## Purpose
Related Issue: https://github.com/wso2-enterprise/choreo/issues/29157
