### PR TITLE
[PE Docs] Update for managing continuous deployment pipelines

### DIFF
--- a/en/developer-docs/docs/devops-and-ci-cd/manage-continuous-deployment-pipelines.md
+++ b/en/developer-docs/docs/devops-and-ci-cd/manage-continuous-deployment-pipelines.md
@@ -104,4 +104,8 @@ To change the default pipeline of a project, follow the steps given below:
 2. In the Choreo Console, go to the top navigation menu and click **Organization**. Then select your organization.
 3. Click the project you want to change the default pipeline.
 4. In the left navigation menu, click **DevOps** and then click **CD Pipelines**.
-5. Click **Set as Default** corresponding to the pipeline you want to set as the default pipeline for the project.
+5. Click **Set as Default** corresponding to the pipeline you want to set as the default pipeline for the project. This displays a confirmation dialog that details the impact of setting the new pipeline as the project default.
+6. Click **Confirm**.
+
+    !!! info "Note"
+        The **default** continuous deployment pipeline is configured separately at both the organization and project levels. When a project is created, it inherits the organization's **default** pipeline. The project's **default** pipeline then defines the default promotion order for its components on the Deploy page.


### PR DESCRIPTION
## Purpose

related to 
- https://github.com/wso2-enterprise/choreo/issues/32510
- https://github.com/wso2-enterprise/choreo/issues/34103

This pull request includes a change to the documentation for managing continuous deployment pipelines. The change clarifies the steps to set a default pipeline for a project and adds a note to explain the difference between the organization default and the project default.

Documentation update:

* [`en/docs/devops-and-ci-cd/manage-continuous-deployment-pipelines.md`](diffhunk://#diff-579e845a01e7a3ecfc0ec4d172d5760f7971aa7bcf60022facc5e61bbe6695e8L107-R111): Updated the instructions to include a confirmation dialog step and added a note explaining the difference between the organization default and the project default settings.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs
