### PR TITLE
Fix mysql db creation steps in Developer Docs

### DIFF
--- a/en/developer-docs/docs/manage-databases-and-caches/choreo-managed-mysql-databases.md
+++ b/en/developer-docs/docs/manage-databases-and-caches/choreo-managed-mysql-databases.md
@@ -6,15 +6,16 @@ MySQL on Choreo offers fully managed, flexible relational databases on AWS, Azur
 
 Follow the steps below to create a Choreo-managed MySQL database: 
 
-1. From the environment list on the header, located next to the **Deployment Tracks** list, select your **Organization**.
-2. In the left navigation menu, click **Resources** and then **Databases**.
-3. Click **Create** and select **MySQL** as the database type. Provide a display name for this server and follow the instructions.
-4. Select your preferred cloud provider from AWS, Azure, GCP, and Digital Ocean.
+1. Sign in to the [Choreo Console](https://console.choreo.dev/).
+2. In the Choreo Console header, go to the **Organization** list and select your organization.
+3. In the left navigation menu, click **Resources** and then **Databases**.
+4. Click **Create** and select **MySQL** as the database type. Provide a display name for this server and follow the instructions.
+5. Select your preferred cloud provider from AWS, Azure, GCP, and Digital Ocean.
   - Choreo uses the cloud provider to provision the compute and storage infrastructure for your database.
   - There is no functional difference between databases created on different cloud providers, apart from changes to service plans (and associated costs). 
-5. Choose the region for your database.
+6. Choose the region for your database.
   - Available regions will depend on the selected cloud provider. Choreo currently supports US and EU regions across all providers.
-6. Select the service plan.
+7. Select the service plan.
   - Service plans vary in the dedicated CPU, memory (RAM), storage space allocated for your database, the backup retention periods, and high-availability configurations for production use cases.
 
 ## Connect to your Choreo-managed MySQL database


### PR DESCRIPTION
## Description
The current doc contains invalid instructions for MySQL DB provisioning

<img width="984" alt="Screenshot 2025-05-26 at 12 18 56" src="https://github.com/user-attachments/assets/499df243-4a47-4d17-99b9-0613fc467bf2" />

### Doc with Correct Instructions

<img width="1003" alt="Screenshot 2025-05-26 at 12 47 10" src="https://github.com/user-attachments/assets/163a6273-8ca6-4d75-81a8-b4aa4db096f9" />


## Type

 of change

- [x] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [ ] Change is applicable for both Developer and Platform Engineer views

## Testing

- [ ] Change is tested in Developer view
- [ ] Change is tested in Platform Engineer view

## Related issues
> List related issues here
