### PR TITLE
Fix typo in deployment tracks documentation

### DIFF
--- a/en/developer-docs/docs/choreo-concepts/deployment-tracks.md
+++ b/en/developer-docs/docs/choreo-concepts/deployment-tracks.md
@@ -43,7 +43,7 @@ You can follow the approach given below when you version APIs in Choreo:
 
 One of the primary concerns when dealing with SaaS APIs is to minimize disruption for API consumers while continuously developing and deploying updates.
 
-In compliance with SemVer, changes that don't introduce breaking or additive modifications to the API are categorized as patch updates. Hover, from the perspective of API consumers, these changes should ideally not disrupt their API clients. Typically, API consumers are most concerned with major API version alterations, but there might be instances where minor version changes are communicated to them.
+In compliance with SemVer, changes that don't introduce breaking or additive modifications to the API are categorized as patch updates. However, from the perspective of API consumers, these changes should ideally not disrupt their API clients. Typically, API consumers are most concerned with major API version alterations, but there might be instances where minor version changes are communicated to them.
 
 Therefore, in the context of deployment tracks, API developers only need to specify the major and minor versions being delivered from a particular deployment track. This information is treated as the API version attribute of a deployment track. If the publisher requires versioning for internal tracking purposes, this can be accomplished in Git through the use of Git tags, on GitHub with GitHub releases, and so forth.
 

--- a/en/pe-docs/docs/choreo-concepts/deployment-tracks.md
+++ b/en/pe-docs/docs/choreo-concepts/deployment-tracks.md
@@ -43,7 +43,7 @@ You can follow the approach given below when you version APIs in Choreo:
 
 One of the primary concerns when dealing with SaaS APIs is to minimize disruption for API consumers while continuously developing and deploying updates.
 
-In compliance with SemVer, changes that don't introduce breaking or additive modifications to the API are categorized as patch updates. Hover, from the perspective of API consumers, these changes should ideally not disrupt their API clients. Typically, API consumers are most concerned with major API version alterations, but there might be instances where minor version changes are communicated to them.
+In compliance with SemVer, changes that don't introduce breaking or additive modifications to the API are categorized as patch updates. However, from the perspective of API consumers, these changes should ideally not disrupt their API clients. Typically, API consumers are most concerned with major API version alterations, but there might be instances where minor version changes are communicated to them.
 
 Therefore, in the context of deployment tracks, API developers only need to specify the major and minor versions being delivered from a particular deployment track. This information is treated as the API version attribute of a deployment track. If the publisher requires versioning for internal tracking purposes, this can be accomplished in Git through the use of Git tags, on GitHub with GitHub releases, and so forth.
 


### PR DESCRIPTION
## Description
Fixing the typo highlighted in the screenshot below

<img width="1231" alt="Screenshot 2025-06-02 at 15 14 46" src="https://github.com/user-attachments/assets/7afa0d49-1817-46e2-8562-565168129222" />

## Type of change

- [ ] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [x] Change is applicable for both Developer and Platform Engineer views

## Testing

- [x] Change is tested in Developer view
- [x] Change is tested in Platform Engineer view

## Related issues
> List related issues here
