### PR TITLE
Update FAQ section on region selector and project creation

### DIFF
--- a/en/developer-docs/docs/references/faq.md
+++ b/en/developer-docs/docs/references/faq.md
@@ -48,9 +48,14 @@ Ballerina is an open-source programming language designed for the cloud. It simp
 Asgardeo is an identity provider (IdP) that allows developers to secure access for consumers, business partners, employees, and APIs. Asgardeo is Choreo’s default IDP. To learn more, visit https://wso2.com/asgardeo/.
 
 ### Q: Why don’t I see the region selector on the project creation page?
-If you are a Choreo cloud data plane user, you can create projects in multiple regions only if you have a paid subscription in Choreo. Otherwise, your projects will be created in the same region you selected when onboarding the organization.
+The region selector has been removed. Projects derive their region(s) from the Environments available to them through the assigned [Continuous Deployment (CD) Pipeline](https://wso2.com/choreo/docs/devops-and-ci-cd/manage-continuous-deployment-pipelines/). Additional Environments can be made available to a Project by defining a new CD Pipeline at the Organization and then assigning it to that Project or adding the environments to the project assigned pipeline.
+To target a specific region (for example, EU), on a Cloud Data Plane (CDP), you must:
 
-If you are a private data plane user, there will be no region selector in project creation at all.
+- Create a new Environment (or a set of Environments) on the EU CDP under your Organization.
+- Create a new CD Pipeline that deploys to these new Environments on the EU CDP or add the environments to the project assigned pipeline.
+- Assign this CD Pipeline to your Project.
+
+The same concept applies for Private Data Planes (PDPs) as well, but the region(s) are decided based on where your PDP is physically located.
 
 ### Q: As a Cloud Data Plane user, how can I create components in multiple data planes?
 When an organization admin onboards a new organization in Choreo, they can choose the preferred data plane. Choreo then sets the selected data plane as the default for the entire organization. Subsequently, users within the free tier of the cloud data plane can create components only in the set default data plane. If a free-tier user needs to create components in a different data plane, the user must get a paid subscription.


### PR DESCRIPTION
## Description

This pull request updates the FAQ documentation in `en/developer-docs/docs/references/faq.md` to clarify how regions are managed for projects in Choreo. The region selector has been removed, and the process for targeting specific regions has been updated to reflect the use of Continuous Deployment (CD) Pipelines.

### Updates to region management in Choreo:

* Removed the region selector from the project creation page. Projects now derive their region(s) from the Environments defined in the assigned CD Pipeline.
* Added detailed instructions for targeting specific regions, including creating new Environments, defining CD Pipelines, and assigning them to projects.
* Clarified region management for Private Data Planes (PDPs), where regions are determined by the physical location of the PDP.


![image](https://github.com/user-attachments/assets/482df456-46f0-4373-b092-4220daa9fec7)

## Type of change

- [ ] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [x] Change is applicable for both Developer and Platform Engineer views

## Testing

- [ ] Change is tested in Developer view
- [ ] Change is tested in Platform Engineer view

## Related issues
> List related issues here
