### PR TITLE
Improve the config.js related inconsistencies

### DIFF
--- a/en/developer-docs/docs/develop-components/develop-web-applications/build-and-deploy-a-single-page-web-application.md
+++ b/en/developer-docs/docs/develop-components/develop-web-applications/build-and-deploy-a-single-page-web-application.md
@@ -158,7 +158,7 @@ For SPAs that run completely on the browser, Choreo does not support *baking-in*
     </head>
     <body>
         <div id="root"></div>
-        <script src="%PUBLIC_URL%/config.js"></script>
+        <script src="./public/config.js"></script>
     </body>
     </html>
     ```

--- a/en/developer-docs/docs/develop-components/sharing-and-reusing/use-a-connection-in-your-web-application.md
+++ b/en/developer-docs/docs/develop-components/sharing-and-reusing/use-a-connection-in-your-web-application.md
@@ -39,7 +39,7 @@ To connect to a selected service, follow the step-by-step instructions given bel
         </head>
         <body>
             <div id="root"></div>
-            <script src="/public/config.js"></script>
+            <script src="./public/config.js"></script>
         </body>
         </html>
         ``` 
@@ -104,7 +104,7 @@ To connect to a selected service, follow the step-by-step instructions given bel
         </head>
         <body>
             <div id="root"></div>
-            <script src="/public/config.js"></script>
+            <script src="./public/config.js"></script>
         </body>
         </html>
         ``` 

--- a/en/developer-docs/docs/quick-start-guides/deploy-a-web-application-that-consumes-a-backend-service.md
+++ b/en/developer-docs/docs/quick-start-guides/deploy-a-web-application-that-consumes-a-backend-service.md
@@ -230,8 +230,8 @@ A connection allows you to integrate the service with other services or external
     };
     ```
 
-    !!! tip
-        You can refer to the configuration file mounted at `/app/public` as `./public/config.js` within your web application.
+    !!! note
+        You must refer to the configuration file mounted at `/app/public` as `./public/config.js` within your web application.
 
 4. Click **Next** to open the **Authentication** pane.
 5. Under **Authentication Settings**, ensure that **Managed authentication with Choreo** is enabled.

--- a/en/developer-docs/docs/tutorials/consume-an-api-hosted-in-choreo.md
+++ b/en/developer-docs/docs/tutorials/consume-an-api-hosted-in-choreo.md
@@ -145,8 +145,8 @@ To configure the front-end application:
     | **asgardeoBaseUrl**   | The IdP API URL with your organization name (e.g., `https://api.asgardeo.io/t/<ORG_NAME>`). |
     | **choreoApiUrl**      | The **Reading List Service** URL from the endpoint table in the overview page. |
         
-    !!! tip
-        You can refer to the mounted configuration file as `./public/config.js` within your web application.
+    !!! note
+        You must refer to the mounted configuration file as `./public/config.js` within your web application.
     
 5. Click **Deploy**.
 6. Once deployed, copy the **Web App URL** from the development environment card.


### PR DESCRIPTION
## Description

related to https://github.com/wso2-enterprise/choreo/issues/36393

This pull request updates documentation across multiple files to standardize the path used for referencing the `config.js` file and clarify instructions regarding its usage. The changes ensure consistency and improve the accuracy of the documentation.

### Standardization of `config.js` path references:

* [`en/developer-docs/docs/develop-components/develop-web-applications/build-and-deploy-a-single-page-web-application.md`](diffhunk://#diff-3649c70fcb46d341c7353d04b895f8ce238207b29842ad9ae27101e3d3957b94L161-R161): Updated the script tag to use `./public/config.js` instead of `%PUBLIC_URL%/config.js`.
* [`en/developer-docs/docs/develop-components/sharing-and-reusing/use-a-connection-in-your-web-application.md`](diffhunk://#diff-876912d606ad6efb330ff91611099baeb1d4b590d217a576a72498fd24036e34L42-R42): Replaced `/public/config.js` with `./public/config.js` in two instances to ensure consistent path usage. [[1]](diffhunk://#diff-876912d606ad6efb330ff91611099baeb1d4b590d217a576a72498fd24036e34L42-R42) [[2]](diffhunk://#diff-876912d606ad6efb330ff91611099baeb1d4b590d217a576a72498fd24036e34L107-R107)

### Clarification of instructions regarding `config.js`:

* [`en/developer-docs/docs/quick-start-guides/deploy-a-web-application-that-consumes-a-backend-service.md`](diffhunk://#diff-973040bdabce9169e0f7374fa23bbb31c55e41909721b92ac67935de6a228996L233-R234): Changed a tip to a note, emphasizing the mandatory usage of `./public/config.js` for referring to the configuration file.
* [`en/developer-docs/docs/tutorials/consume-an-api-hosted-in-choreo.md`](diffhunk://#diff-64d039ecc37ccc3ad4283a8928967b644d8b3ea8f3c9673efb9b587922f0f2e8L148-R149): Updated a tip to a note to clearly state the requirement to use `./public/config.js` for referencing the mounted configuration file.

## Type of change

- [ ] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [x] Change is applicable for both Developer and Platform Engineer views

## Testing

- [ ] Change is tested in Developer view
- [ ] Change is tested in Platform Engineer view

## Related issues
> List related issues here
