### PR TITLE
Update configuration groups documentation to update unsupported components

### DIFF
--- a/en/developer-docs/docs/devops-and-ci-cd/manage-configuration-groups.md
+++ b/en/developer-docs/docs/devops-and-ci-cd/manage-configuration-groups.md
@@ -9,7 +9,7 @@ Configuration groups can be defined at organization level and link to components
     - All configuration group values are encrypted and stored in environment-specific key vaults.
     - Management of configuration groups is restricted to users with Choreo Admin, DevOps, and Platform Engineer roles.
     - Developers can discover configuration groups available within the organization via the **Choreo Internal Marketplace**.
-    - This feature is currently not supported for WSO2 MI and Ballerina buildpacks, or for Web Application and Test Runner components.
+    - This feature is currently not supported for Ballerina buildpacks, Web Applications, or Test Runner components.
 
 ## Create a configuration group
 

--- a/en/pe-docs/docs/devops/manage-configuration-groups.md
+++ b/en/pe-docs/docs/devops/manage-configuration-groups.md
@@ -9,7 +9,7 @@ Configuration groups can be defined at organization level and link to components
     - All configuration group values are encrypted and stored in environment-specific key vaults.
     - Management of configuration groups is restricted to users with Choreo Admin, DevOps, and Platform Engineer roles.
     - Developers can discover configuration groups available within the organization via the **Choreo Internal Marketplace**.
-    - This feature is currently not supported for WSO2 MI and Ballerina buildpacks, or for Web Application and Test Runner components.
+    - This feature is currently not supported for Ballerina buildpacks, Web Applications, or Test Runner components.
 
 ## Create a configuration group
 


### PR DESCRIPTION
## Description
> Update configuration group documentation since configuration groups are supported for MI components

Related 
- https://github.com/wso2-enterprise/choreo/issues/36470
- https://github.com/wso2-enterprise/choreo/issues/35089

## Type of change

- [ ] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [x] Change is applicable for both Developer and Platform Engineer views

## Testing

- [ ] Change is tested in Developer view
- [ ] Change is tested in Platform Engineer view

## Related issues
> List related issues here
