### PR TITLE
Adds tier limitation note for URL customization

### DIFF
--- a/en/developer-docs/docs/administer/configure-a-custom-domain-for-your-organization.md
+++ b/en/developer-docs/docs/administer/configure-a-custom-domain-for-your-organization.md
@@ -2,6 +2,9 @@
 
 A custom domain is essential for effective branding, discoverability, and credibility of a website. Choreo allows you to easily configure custom domains for your organization, enabling developers to utilize it to configure custom URLs for their components such as API proxies, services, web applications, and webhooks.
 
+!!! info "Note"
+    The Custom Domains feature is provided exclusively to paid subscribers. Free‑tier organizations do not have access to custom domain configuration.
+
 This section provides an overview of Choreo’s custom domain configuration model and guides you through configuring a custom domain for your organization. It also walks you through utilizing a custom domain to configure a custom URL for a component.
 
 ## Choreo custom domain configuration model

--- a/en/developer-docs/docs/administer/configure-a-custom-domain-for-your-organization.md
+++ b/en/developer-docs/docs/administer/configure-a-custom-domain-for-your-organization.md
@@ -3,7 +3,7 @@
 A custom domain is essential for effective branding, discoverability, and credibility of a website. Choreo allows you to easily configure custom domains for your organization, enabling developers to utilize it to configure custom URLs for their components such as API proxies, services, web applications, and webhooks.
 
 !!! info "Note"
-    The Custom Domains feature is provided exclusively to paid subscribers. Free‑tier organizations do not have access to custom domain configuration.
+    The Custom Domains feature is provided exclusively to paid subscribers. Free-tier organizations do not have access to custom domain configuration.
 
 This section provides an overview of Choreo’s custom domain configuration model and guides you through configuring a custom domain for your organization. It also walks you through utilizing a custom domain to configure a custom URL for a component.
 

--- a/en/pe-docs/docs/infrastructure/domains/configure-a-custom-domain-for-your-organization.md
+++ b/en/pe-docs/docs/infrastructure/domains/configure-a-custom-domain-for-your-organization.md
@@ -4,7 +4,7 @@
 A custom domain is essential for effective branding, discoverability, and credibility of a website. Choreo allows you to easily configure custom domains for your organization, enabling developers to utilize it to configure custom URLs for their components such as API proxies, services, web applications, and webhooks.
 
 !!! info "Note"
-    The Custom Domains feature is provided exclusively to paid subscribers. Free‑tier organizations do not have access to custom domain configuration.
+    The Custom Domains feature is provided exclusively to paid subscribers. Free-tier organizations do not have access to custom domain configuration.
 
 This section provides an overview of Choreo’s custom domain configuration model and guides you through configuring a custom domain for your organization.
 

--- a/en/pe-docs/docs/infrastructure/domains/configure-a-custom-domain-for-your-organization.md
+++ b/en/pe-docs/docs/infrastructure/domains/configure-a-custom-domain-for-your-organization.md
@@ -3,6 +3,9 @@
 
 A custom domain is essential for effective branding, discoverability, and credibility of a website. Choreo allows you to easily configure custom domains for your organization, enabling developers to utilize it to configure custom URLs for their components such as API proxies, services, web applications, and webhooks.
 
+!!! info "Note"
+    The Custom Domains feature is provided exclusively to paid subscribers. Free‑tier organizations do not have access to custom domain configuration.
+
 This section provides an overview of Choreo’s custom domain configuration model and guides you through configuring a custom domain for your organization.
 
 ## Choreo custom domain configuration model


### PR DESCRIPTION
## Description
This PR adds a tier limitation note to the custom domain configuration documentation, clarifying that custom domains are only available to paid subscribers. The change ensures users understand this feature restriction before attempting to configure custom domains.

Key changes:
- Added an informational note about tier limitations for custom domain features
- Applied the same note consistently across both developer and platform engineer documentation

<img width="1280" height="597" alt="image" src="https://github.com/user-attachments/assets/901cc95c-edd4-4f1f-9896-39b5ce8abead" />


## Type of change

- [ ] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [x] Change is applicable for both Developer and Platform Engineer views

## Testing

- [x] Change is tested in Developer view
- [x] Change is tested in Platform Engineer view

## Related issues
> List related issues here
