### PR TITLE
Update config file mount for web apps

### DIFF
--- a/en/developer-docs/docs/develop-components/sharing-and-reusing/use-a-connection-in-your-web-application.md
+++ b/en/developer-docs/docs/develop-components/sharing-and-reusing/use-a-connection-in-your-web-application.md
@@ -39,7 +39,7 @@ To connect to a selected service, follow the step-by-step instructions given bel
         </head>
         <body>
             <div id="root"></div>
-            <script src="/public/config.js"></script>
+            <script src="./config.js"></script>
         </body>
         </html>
         ``` 
@@ -104,7 +104,7 @@ To connect to a selected service, follow the step-by-step instructions given bel
         </head>
         <body>
             <div id="root"></div>
-            <script src="/public/config.js"></script>
+            <script src="./config.js"></script>
         </body>
         </html>
         ``` 

--- a/en/developer-docs/docs/quick-start-guides/deploy-a-web-application-that-consumes-a-backend-service.md
+++ b/en/developer-docs/docs/quick-start-guides/deploy-a-web-application-that-consumes-a-backend-service.md
@@ -231,7 +231,7 @@ A connection allows you to integrate the service with other services or external
     ```
 
     !!! tip
-        You can refer to the configuration file mounted at `/app/public` as `./public/config.js` within your web application.
+        You can refer to the mounted configuration file as `./config.js` within your web application.
 
 4. Click **Next** to open the **Authentication** pane.
 5. Under **Authentication Settings**, ensure that **Managed authentication with Choreo** is enabled.

--- a/en/developer-docs/docs/references/troubleshoot-choreo.md
+++ b/en/developer-docs/docs/references/troubleshoot-choreo.md
@@ -25,7 +25,7 @@ To resolve the issue, follow the guidelines given below:
        1. Add the `config.js` file to the `app/public` directory in your repository.
        2. Reference it from the `index.html` file by adding a script tag as follows:
 
-           `<script src="public/config.js"></script>`
+           `<script src="./config.js"></script>`
 
 ## Troubleshoot component deployment errors
 
@@ -35,7 +35,7 @@ To resolve the issue, follow the guidelines given below:
 
        - Reference the `config.js` file from the `index.html` file of your application by adding a script tag as follows:  
 
-          `<script src="public/config.js"></script>` 
+          `<script src="./config.js"></script>` 
 
        - Verify that the path in the script tag matches the location where the `config.js` file is stored in your repository.
        - Make sure the script tag is placed within the `<body>` tag in your `index.html` file. You must ensure that it is not mistakenly placed within another HTML element.

--- a/en/developer-docs/docs/tutorials/consume-an-api-hosted-in-choreo.md
+++ b/en/developer-docs/docs/tutorials/consume-an-api-hosted-in-choreo.md
@@ -146,7 +146,7 @@ To configure the front-end application:
     | **choreoApiUrl**      | The **Reading List Service** URL from the endpoint table in the overview page. |
         
     !!! tip
-        You can refer to the mounted configuration file as `./public/config.js` within your web application.
+        You can refer to the mounted configuration file as `./config.js` within your web application.
     
 5. Click **Deploy**.
 6. Once deployed, copy the **Web App URL** from the development environment card.

--- a/en/pe-docs/docs/references/troubleshoot-choreo.md
+++ b/en/pe-docs/docs/references/troubleshoot-choreo.md
@@ -25,7 +25,7 @@ To resolve the issue, follow the guidelines given below:
        1. Add the `config.js` file to the `app/public` directory in your repository.
        2. Reference it from the `index.html` file by adding a script tag as follows:
 
-           `<script src="public/config.js"></script>`
+           `<script src="./config.js"></script>`
 
 ## Troubleshoot component deployment errors
 
@@ -35,7 +35,7 @@ To resolve the issue, follow the guidelines given below:
 
        - Reference the `config.js` file from the `index.html` file of your application by adding a script tag as follows:  
 
-          `<script src="public/config.js"></script>` 
+          `<script src="./config.js"></script>` 
 
        - Verify that the path in the script tag matches the location where the `config.js` file is stored in your repository.
        - Make sure the script tag is placed within the `<body>` tag in your `index.html` file. You must ensure that it is not mistakenly placed within another HTML element.


### PR DESCRIPTION
## Description

This pull request updates multiple developer documentation files to standardize how the `config.js` file is referenced in web applications. The main change is replacing various references to `public/config.js` with `./config.js` to ensure consistency and correctness in script tag usage across guides and troubleshooting sections.

**Documentation consistency and correctness:**

* Updated all script tag references in setup instructions to use `./config.js` instead of `public/config.js` in `index.html` examples and tips. [[1]](diffhunk://#diff-876912d606ad6efb330ff91611099baeb1d4b590d217a576a72498fd24036e34L42-R42) [[2]](diffhunk://#diff-876912d606ad6efb330ff91611099baeb1d4b590d217a576a72498fd24036e34L107-R107) [[3]](diffhunk://#diff-90b34c6fcb9c1a9a6b2497109d9bf853cbe13dd407c182045651f80341115127L28-R28) [[4]](diffhunk://#diff-90b34c6fcb9c1a9a6b2497109d9bf853cbe13dd407c182045651f80341115127L38-R38) [[5]](diffhunk://#diff-417aacaa55e99b0507ed12fb6a17867c4ddcda490ea648acf63b9958c2f49271L28-R28) [[6]](diffhunk://#diff-417aacaa55e99b0507ed12fb6a17867c4ddcda490ea648acf63b9958c2f49271L38-R38)
* Revised tips and guidance in quick start and tutorial docs to instruct users to refer to the mounted config file as `./config.js`. [[1]](diffhunk://#diff-973040bdabce9169e0f7374fa23bbb31c55e41909721b92ac67935de6a228996L234-R234) [[2]](diffhunk://#diff-64d039ecc37ccc3ad4283a8928967b644d8b3ea8f3c9673efb9b587922f0f2e8L149-R149)

## Type of change

- [ ] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [x] Change is applicable for both Developer and Platform Engineer views

## Testing

- [ ] Change is tested in Developer view
- [ ] Change is tested in Platform Engineer view

## Related issues
https://github.com/wso2-enterprise/choreo/issues/36393