### PR TITLE
Deprecate component-config and endpoints yaml file

### DIFF
--- a/en/developer-docs/docs/develop-components/manage-component-source-configurations.md
+++ b/en/developer-docs/docs/develop-components/manage-component-source-configurations.md
@@ -415,7 +415,7 @@ Click the respective tab to view the structure for your current configuration fi
     !!! note
         Choreo automatically generates connection configurations when you create a connection. The properties such as **name**, **connectionConfig**, and **env.from** are automatically generated. However, you must manually set the **env.to** value.
 
-## Overview of the `component-config.yaml` file 
+## Overview of the `component-config.yaml` file(deprecated) 
 
 **File location**:
 
@@ -494,7 +494,7 @@ You must include the following configurations in the `serviceReferences` schema:
 | **env.from**         | Required     | The key name of the connection configuration.                                    |
 | **env.to**           | Required     | The environment variable to inject into the container.                           |
 
-## Overview of the `endpoints.yaml` file
+## Overview of the `endpoints.yaml` file(deprecated)
 
 **File location**:
 


### PR DESCRIPTION
## Description
This pull request updates documentation to clarify that both the `component-config.yaml` and `endpoints.yaml` files are deprecated. The changes help prevent confusion for developers by clearly marking these configuration files as deprecated in their respective overview sections.

Documentation updates:

* Updated the section header to `Overview of the component-config.yaml file(deprecated)` to indicate that this file is deprecated.
* Updated the section header to `Overview of the endpoints.yaml file(deprecated)` to indicate that this file is deprecated.

## Type of change

- [ ] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [x] Change is applicable for both Developer and Platform Engineer views

## Testing

- [ ] Change is tested in Developer view
- [ ] Change is tested in Platform Engineer view

## Related issues
> List related issues here
