### PR TITLE
Improve custom policy defining doc considering the same parameter  names and order requirement

### DIFF
--- a/en/developer-docs/docs/api-management/api-policies/attach-and-manage-policies.md
+++ b/en/developer-docs/docs/api-management/api-policies/attach-and-manage-policies.md
@@ -194,7 +194,9 @@ public function validateResponseHeader(mediation:Context ctx, http:Request req, 
 In this guide, you are not going to make any changes to the `Fault` flow. Therefore, you can remove the `Fault` flow stub from the `policy.bal` file.
 
 !!! note 
-    The  **@mediation:RequestFlow**, **@mediation:ResponseFlow**, and **@mediation:FaultFlow** annotations are bound with the keywords in the `Ballerina.toml`. Therefore, the changes you make to the policy stubs should reflect in the `Ballerina.toml` file. For example, if the policy is applicable only on the request and response paths, you can remove the  **@mediation:FaultFlow** annotation from the policy. Then, you **MUST** also remove the **choreo-apim-mediation-fault-flow** keyword from the generated `Ballerina.toml` file. If you do not do so, the Ballerina compiler will show an error at compile time.
+    - The  **@mediation:RequestFlow**, **@mediation:ResponseFlow**, and **@mediation:FaultFlow** annotations are bound with the keywords in the `Ballerina.toml`. Therefore, the changes you make to the policy stubs should reflect in the `Ballerina.toml` file. For example, if the policy is applicable only on the request and response paths, you can remove the  **@mediation:FaultFlow** annotation from the policy. Then, you **MUST** also remove the **choreo-apim-mediation-fault-flow** keyword from the generated `Ballerina.toml` file. If you do not do so, the Ballerina compiler will show an error at compile time.
+
+    - If you choose not to remove the Fault flow, ensure that the parameter order and names are consistent with  defined Request and Response flows.
 
 #### Publish as a private custom policy
  

--- a/en/developer-docs/docs/api-management/api-policies/attach-and-manage-policies.md
+++ b/en/developer-docs/docs/api-management/api-policies/attach-and-manage-policies.md
@@ -196,7 +196,7 @@ In this guide, you are not going to make any changes to the `Fault` flow. Theref
 !!! note 
     - The  **@mediation:RequestFlow**, **@mediation:ResponseFlow**, and **@mediation:FaultFlow** annotations are bound with the keywords in the `Ballerina.toml`. Therefore, the changes you make to the policy stubs should reflect in the `Ballerina.toml` file. For example, if the policy is applicable only on the request and response paths, you can remove the  **@mediation:FaultFlow** annotation from the policy. Then, you **MUST** also remove the **choreo-apim-mediation-fault-flow** keyword from the generated `Ballerina.toml` file. If you do not do so, the Ballerina compiler will show an error at compile time.
 
-    - If you choose not to remove the Fault flow, ensure that the parameter order and names are consistent with  defined Request and Response flows.
+    - If you choose not to remove the Fault flow, ensure that the parameter order and names are consistent with defined Request and Response flows.
 
 #### Publish as a private custom policy
  

--- a/en/theme/material/partials/copyright_2.html
+++ b/en/theme/material/partials/copyright_2.html
@@ -3,7 +3,7 @@
 -#}
   <div class="footer-copyright-right">
     <div class="footer-copyright-top">
-      Copyright &copy; <a href="https://wso2.com/">WSO2</a> LLC (2023-2024)
+      Copyright &copy; <a href="https://wso2.com/">WSO2</a> LLC (2023-2025)
     </div>
     <div class="footer-copyright-bottom">
       Content licensed under <a href="https://creativecommons.org/licenses/by/4.0">CC By 4.0.</a> | Sample code


### PR DESCRIPTION


## Description
$subject

<img width="1142" height="588" alt="image" src="https://github.com/user-attachments/assets/e69d9499-a8f2-48bc-a0d7-fe31f07fe37c" />


<img width="608" height="138" alt="image" src="https://github.com/user-attachments/assets/aba7527b-6140-4b2c-92ae-c83ee0602a5c" />


## Type of change

- [x] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [ ] Change is applicable for both Developer and Platform Engineer views

## Testing

- [ ] Change is tested in Developer view
- [ ] Change is tested in Platform Engineer view

## Related issues
> List related issues here
