### PR TITLE
Add tip to specify env wise access control is only available in slected orgs

### DIFF
--- a/en/developer-docs/docs/administer/configure-access-control.md
+++ b/en/developer-docs/docs/administer/configure-access-control.md
@@ -53,6 +53,10 @@ Follow the steps given below to assign the **Developer** role to the **Engineeri
 5. Click **+Assign Roles**. 
 6. In the **Assign Roles to Group in Project** dialog that opens, click the **Roles** list and select **Developer**.
 7. Click **Selected Environments** radio button under **Applicable Environments**
+
+!!! tip
+    Configuring the Applicable Environment for a Role to Group assignment is currently available only for selected organizations.
+
 8. Select **Development** environment from the environment selecction dropdown 
 7. Click **Assign**. This assigns the **Developer** role to the group. You should see the mapping level as **Project (Engineering Project)** and Applicable Environment as **Development** indicating the type of the asssignment:
 

--- a/en/developer-docs/docs/administer/configure-access-control.md
+++ b/en/developer-docs/docs/administer/configure-access-control.md
@@ -54,7 +54,7 @@ Follow the steps given below to assign the **Developer** role to the **Engineeri
 6. In the **Assign Roles to Group in Project** dialog that opens, click the **Roles** list and select **Developer**.
 7. Click **Selected Environments** radio button under **Applicable Environments**
 
-!!! tip
+!!! warning "Important"
     Configuring the Applicable Environment for a Role to Group assignment is currently available only for selected organizations.
 
 8. Select **Development** environment from the environment selecction dropdown 

--- a/en/developer-docs/docs/choreo-concepts/access-control.md
+++ b/en/developer-docs/docs/choreo-concepts/access-control.md
@@ -70,6 +70,9 @@ By combining these attributes, you can create four types of assignments.
 |`Environement Scoped`|Organization|Environment|
 |`Project-Environment Scoped`|Project|Environment|
 
+!!! tip
+    Configuring the Applicable Environment for a Role to Group assignment is currently available only for selected organizations.
+
 !!! warning "Important"
     Avoid assigning multiple roles to the same group across different projects or mapping levels (organization and project). Doing so can give users unintended permissions in some projects, allowing access to tasks they shouldn’t perform. To ensure proper access control, assign only one role to a group across projects or mapping levels.
 
@@ -114,6 +117,9 @@ For environement scoped assignments, allowing **non environment specific** actio
 !!! example
     Suppose you assign the Developer role to the Engineering Developer group, but only for the Development environment of the Engineering project. The purpose of this assignment is not to prevent developers from performing actions like `build component`, which don’t depend on a specific environment. Instead, the goal is to restrict developers from performing actions such as `promote component` on environments they aren’t authorized to access, like Production.
 
+!!! tip
+    Environment Scoped Assignments are currently available only for selected organizations.
+
 !!! warning "Important"
     Exercise care when creating environment scoped role-to-group assignments. Only environment specific actions are restricted to that environment; all other actions remain allowed on resources across the organization.
 
@@ -124,6 +130,9 @@ For environement scoped assignments, allowing **non environment specific** actio
 - All other actions are not allowed.
 
 Similar to previous case, allowing **non environment specific** actions on resources across project is intentional. This design aligns with real world Access Control use cases.
+
+!!! tip
+    Project-Environment Scoped Assignments are currently available only for selected organizations.
 
 !!! warning "Important"
     Exercise care when creating project-environment scoped role-to-group assignments. Only environment specific actions are restricted to that environment; all other actions remain allowed on resources across the project.

--- a/en/developer-docs/docs/choreo-concepts/access-control.md
+++ b/en/developer-docs/docs/choreo-concepts/access-control.md
@@ -70,7 +70,7 @@ By combining these attributes, you can create four types of assignments.
 |`Environement Scoped`|Organization|Environment|
 |`Project-Environment Scoped`|Project|Environment|
 
-!!! tip
+!!! warning "Important"
     Configuring the Applicable Environment for a Role to Group assignment is currently available only for selected organizations.
 
 !!! warning "Important"
@@ -117,7 +117,7 @@ For environement scoped assignments, allowing **non environment specific** actio
 !!! example
     Suppose you assign the Developer role to the Engineering Developer group, but only for the Development environment of the Engineering project. The purpose of this assignment is not to prevent developers from performing actions like `build component`, which don’t depend on a specific environment. Instead, the goal is to restrict developers from performing actions such as `promote component` on environments they aren’t authorized to access, like Production.
 
-!!! tip
+!!! warning "Important"
     Environment Scoped Assignments are currently available only for selected organizations.
 
 !!! warning "Important"
@@ -131,7 +131,7 @@ For environement scoped assignments, allowing **non environment specific** actio
 
 Similar to previous case, allowing **non environment specific** actions on resources across project is intentional. This design aligns with real world Access Control use cases.
 
-!!! tip
+!!! warning "Important"
     Project-Environment Scoped Assignments are currently available only for selected organizations.
 
 !!! warning "Important"

--- a/en/pe-docs/docs/choreo-concepts/access-control.md
+++ b/en/pe-docs/docs/choreo-concepts/access-control.md
@@ -70,6 +70,9 @@ By combining these attributes, you can create four types of assignments.
 |`Environement Scoped`|Organization|Environment|
 |`Project-Environment Scoped`|Project|Environment|
 
+!!! tip
+    Configuring the Applicable Environment for a Role to Group assignment is currently available only for selected organizations.
+
 !!! warning "Important"
     Avoid assigning multiple roles to the same group across different projects or mapping levels (organization and project). Doing so can give users unintended permissions in some projects, allowing access to tasks they shouldn’t perform. To ensure proper access control, assign only one role to a group across projects or mapping levels.
 
@@ -114,6 +117,9 @@ For environement scoped assignments, allowing **non environment specific** actio
 !!! example
     Suppose you assign the Developer role to the Engineering Developer group, but only for the Development environment of the Engineering project. The purpose of this assignment is not to prevent developers from performing actions like `build component`, which don’t depend on a specific environment. Instead, the goal is to restrict developers from performing actions such as `promote component` on environments they aren’t authorized to access, like Production.
 
+!!! tip
+    Environment Scoped Assignments are currently available only for selected organizations.
+
 !!! warning "Important"
     Exercise care when creating environment scoped role-to-group assignments. Only environment specific actions are restricted to that environment; all other actions remain allowed on resources across the organization.
 
@@ -124,6 +130,9 @@ For environement scoped assignments, allowing **non environment specific** actio
 - All other actions are not allowed.
 
 Similar to previous case, allowing **non environment specific** actions on resources across project is intentional. This design aligns with real world Access Control use cases.
+
+!!! tip
+    Project-Environment Scoped Assignments are currently available only for selected organizations.
 
 !!! warning "Important"
     Exercise care when creating project-environment scoped role-to-group assignments. Only environment specific actions are restricted to that environment; all other actions remain allowed on resources across the project.

--- a/en/pe-docs/docs/choreo-concepts/access-control.md
+++ b/en/pe-docs/docs/choreo-concepts/access-control.md
@@ -70,7 +70,7 @@ By combining these attributes, you can create four types of assignments.
 |`Environement Scoped`|Organization|Environment|
 |`Project-Environment Scoped`|Project|Environment|
 
-!!! tip
+!!! warning "Important"
     Configuring the Applicable Environment for a Role to Group assignment is currently available only for selected organizations.
 
 !!! warning "Important"
@@ -117,7 +117,7 @@ For environement scoped assignments, allowing **non environment specific** actio
 !!! example
     Suppose you assign the Developer role to the Engineering Developer group, but only for the Development environment of the Engineering project. The purpose of this assignment is not to prevent developers from performing actions like `build component`, which don’t depend on a specific environment. Instead, the goal is to restrict developers from performing actions such as `promote component` on environments they aren’t authorized to access, like Production.
 
-!!! tip
+!!! warning "Important"
     Environment Scoped Assignments are currently available only for selected organizations.
 
 !!! warning "Important"
@@ -131,7 +131,7 @@ For environement scoped assignments, allowing **non environment specific** actio
 
 Similar to previous case, allowing **non environment specific** actions on resources across project is intentional. This design aligns with real world Access Control use cases.
 
-!!! tip
+!!! warning "Important"
     Project-Environment Scoped Assignments are currently available only for selected organizations.
 
 !!! warning "Important"

--- a/en/pe-docs/docs/user-management/groups-and-roles/configure-access-control.md
+++ b/en/pe-docs/docs/user-management/groups-and-roles/configure-access-control.md
@@ -53,6 +53,10 @@ Follow the steps given below to assign the **Developer** role to the **Engineeri
 5. Click **+Assign Roles**. 
 6. In the **Assign Roles to Group in Project** dialog that opens, click the **Roles** list and select **Developer**.
 7. Click **Selected Environments** radio button under **Applicable Environments**
+
+!!! tip
+    Configuring the Applicable Environment for a Role to Group assignment is currently available only for selected organizations.
+
 8. Select **Development** environment from the environment selecction dropdown 
 7. Click **Assign**. This assigns the **Developer** role to the group. You should see the mapping level as **Project (Engineering Project)** and Applicable Environment as **Development** indicating the type of the asssignment:
 

--- a/en/pe-docs/docs/user-management/groups-and-roles/configure-access-control.md
+++ b/en/pe-docs/docs/user-management/groups-and-roles/configure-access-control.md
@@ -54,7 +54,7 @@ Follow the steps given below to assign the **Developer** role to the **Engineeri
 6. In the **Assign Roles to Group in Project** dialog that opens, click the **Roles** list and select **Developer**.
 7. Click **Selected Environments** radio button under **Applicable Environments**
 
-!!! tip
+!!! warning "Important"
     Configuring the Applicable Environment for a Role to Group assignment is currently available only for selected organizations.
 
 8. Select **Development** environment from the environment selecction dropdown 


### PR DESCRIPTION
## Description
$subject

## Type of change

- [ ] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [x] Change is applicable for both Developer and Platform Engineer views

## Testing

- [x] Change is tested in Developer view
- [x] Change is tested in Platform Engineer view

## Related issues
https://github.com/wso2-enterprise/choreo/issues/37333