### PR TITLE
Update docs to include support for Azure DevOps

### DIFF
--- a/en/developer-docs/docs/develop-components/develop-components-with-git.md
+++ b/en/developer-docs/docs/develop-components/develop-components-with-git.md
@@ -1,6 +1,6 @@
 # Develop Components With Git
 
-Choreo enables you to develop components by connecting your GitHub, Bitbucket, or GitLab repository. You have the flexibility to either connect an existing repository or start with an empty repository and commit the source code later. By integrating your repositories with Choreo, you can automate tasks and optimize workflows across multiple systems, all within the Choreo platform.  Choreo currently supports GitHub, Bitbucket, and GitLab as Git providers. 
+Choreo enables you to develop components by connecting your GitHub, Bitbucket, GitLab or Azure DevOps repository. You have the flexibility to either connect an existing repository or start with an empty repository and commit the source code later. By integrating your repositories with Choreo, you can automate tasks and optimize workflows across multiple systems, all within the Choreo platform.  Choreo currently supports GitHub, Bitbucket, GitLab and Azure DevOps as Git providers. 
 
 !!! tip
     Choreo supports both Bitbucket Server and Bitbucket Cloud. The currently supported Bitbucket Server version is 8.9.2.
@@ -104,3 +104,13 @@ Authorizing using a personal access token (PAT) obtained from your GitLab self-m
 |Permission    | Description                                                                         |
 |--------------|-------------------------------------------------------------------------------------|
 |API           | Grants full read/write access to the API, covering all groups and projects, as well as read/write access to the repository.|
+
+## Authorize Azure DevOps with Choreo
+
+Authorizing Choreo using a Personal Access Token (PAT) from Azure DevOps grants Choreo the following permissions to perform actions on your behalf within the selected organization and project.
+
+| Permission   | Read | Write | Description                                                                                           | 
+|--------------|------|-------|------------------------------------------------------------------------------------------------------ |
+| Project      | Y    | N     | Read project metadata to identify and validate the selected Azure DevOps project                      |
+| Team         | Y    | N     | Read team and organization-level information required for repository access                           |
+| Code         | Y    | Y     | Read repository content and branches, and create branches or commits when initializing components     |

--- a/en/developer-docs/docs/references/faq.md
+++ b/en/developer-docs/docs/references/faq.md
@@ -36,7 +36,7 @@ If you have a log monitoring product or service, such as Azure Monitor, you can 
 Choreo allows a maximum request payload size of 50 MB.
 
 ### Q: What source control software does Choreo support?
-Choreo now supports GitHub, Bitbucket and GitLab.
+Choreo now supports GitHub, Bitbucket, GitLab and Azure DevOps.
 
 ### Q: Why don't I see the undeployed builds for my component in Choreo?
 You are allowed to build your component any number of times. However, Choreo has a limit on retaining undeployed builds. For users on the free-tier, Choreo will retain **only one** undeployed build. For those on any other tier, Choreo will retain the **latest five** undeployed builds.

--- a/en/developer-docs/docs/what-is-choreo.md
+++ b/en/developer-docs/docs/what-is-choreo.md
@@ -21,7 +21,7 @@
 ### Development
 - **Language Flexibility**: Use your preferred programming languages to build services, APIs, tasks, and event handlers without changing tools or workflows.
 - **VS Code Integration**: Collaborate and manage code using Visual Studio Code, with support for a familiar, feature-rich development environment.
-- **Git Integration**: Connect to Git-based platforms such as GitHub, Bitbucket, or GitLab by linking an existing repository to develop components.
+- **Git Integration**: Connect to Git-based platforms such as GitHub, Bitbucket, GitLab or Azure DevOps by linking an existing repository to develop components.
 
 ### Deployment
 - **CI/CD**: Automate builds and deployments using Choreo’s integrated CI/CD pipelines. Supports customizable workflows and deployment tracks.

--- a/en/pe-docs/docs/infrastructure/credentials/set-up-git-provider-authentication-for-choreo-deployments.md
+++ b/en/pe-docs/docs/infrastructure/credentials/set-up-git-provider-authentication-for-choreo-deployments.md
@@ -1,6 +1,6 @@
 # Set Up Git Provider Authentication for Choreo Deployments
 
-Choreo enables you to develop components by connecting your GitHub, Bitbucket, GitLab or Azure Devops repository. You have the flexibility to either connect an existing repository or start with an empty repository and commit the source code later. By integrating your repositories with Choreo, you can automate tasks and optimize workflows across multiple systems, all within the Choreo platform.  Choreo currently supports GitHub, Bitbucket, GitLab and Azure DevOps as Git providers. 
+Choreo enables you to develop components by connecting your GitHub, Bitbucket, GitLab or Azure DevOps repository. You have the flexibility to either connect an existing repository or start with an empty repository and commit the source code later. By integrating your repositories with Choreo, you can automate tasks and optimize workflows across multiple systems, all within the Choreo platform.  Choreo currently supports GitHub, Bitbucket, GitLab and Azure DevOps as Git providers. 
 
 !!! tip
     Choreo supports both Bitbucket Server and Bitbucket Cloud. The currently supported Bitbucket Server version is 8.9.2.
@@ -9,7 +9,7 @@ In Choreo, you can connect a Git repository that contains some source code or a 
 
 ## Connect a Git repository to Choreo
 
-You can connect Bitbucket, Gitlab, Azure DevOps repositories to choreo organization using a Personal Access Token(PAT). For github, the developers can install  [WSO2 Cloud App](https://github.com/marketplace/choreo-apps) during component creation and get necessary permissions via Github itself.
+You can connect Bitbucket, GitLab, Azure DevOps repositories to choreo organization using a Personal Access Token (PAT). For GitHub, the developers can install  [WSO2 Cloud App](https://github.com/marketplace/choreo-apps) during component creation and get necessary permissions via GitHub itself.
 
 1. Sign in to the [Choreo Console](https://console.choreo.dev/).
 2. In the Choreo Console header, go to the **Organization** list and select your organization. 

--- a/en/pe-docs/docs/infrastructure/credentials/set-up-git-provider-authentication-for-choreo-deployments.md
+++ b/en/pe-docs/docs/infrastructure/credentials/set-up-git-provider-authentication-for-choreo-deployments.md
@@ -1,6 +1,6 @@
 # Set Up Git Provider Authentication for Choreo Deployments
 
-Choreo enables you to develop components by connecting your GitHub, Bitbucket, or GitLab repository. You have the flexibility to either connect an existing repository or start with an empty repository and commit the source code later. By integrating your repositories with Choreo, you can automate tasks and optimize workflows across multiple systems, all within the Choreo platform.  Choreo currently supports GitHub, Bitbucket, and GitLab as Git providers. 
+Choreo enables you to develop components by connecting your GitHub, Bitbucket, GitLab or Azure Devops repository. You have the flexibility to either connect an existing repository or start with an empty repository and commit the source code later. By integrating your repositories with Choreo, you can automate tasks and optimize workflows across multiple systems, all within the Choreo platform.  Choreo currently supports GitHub, Bitbucket, GitLab and Azure DevOps as Git providers. 
 
 !!! tip
     Choreo supports both Bitbucket Server and Bitbucket Cloud. The currently supported Bitbucket Server version is 8.9.2.
@@ -9,7 +9,7 @@ In Choreo, you can connect a Git repository that contains some source code or a 
 
 ## Connect a Git repository to Choreo
 
-You can connect Bitbucket, Gitlab repositories to choreo organization using a Personal Access Token(PAT). For github, the developers can install  [WSO2 Cloud App](https://github.com/marketplace/choreo-apps) during component creation and get necessary permissions via Github itself.
+You can connect Bitbucket, Gitlab, Azure DevOps repositories to choreo organization using a Personal Access Token(PAT). For github, the developers can install  [WSO2 Cloud App](https://github.com/marketplace/choreo-apps) during component creation and get necessary permissions via Github itself.
 
 1. Sign in to the [Choreo Console](https://console.choreo.dev/).
 2. In the Choreo Console header, go to the **Organization** list and select your organization. 
@@ -49,3 +49,13 @@ Authorizing using a personal access token (PAT) obtained from your GitLab self-m
 |Permission    | Description                                                                         |
 |--------------|-------------------------------------------------------------------------------------|
 |API           | Grants full read/write access to the API, covering all groups and projects, as well as read/write access to the repository.|
+
+## Authorize Azure DevOps with Choreo
+
+Authorizing Choreo using a Personal Access Token (PAT) from Azure DevOps grants Choreo the following permissions to perform actions on your behalf within the selected organization and project.
+
+| Permission   | Read | Write | Description                                                                                           | 
+|--------------|------|-------|------------------------------------------------------------------------------------------------------ |
+| Project      | Y    | N     | Read project metadata to identify and validate the selected Azure DevOps project                      |
+| Team         | Y    | N     | Read team and organization-level information required for repository access                           |
+| Code         | Y    | Y     | Read repository content and branches, and create branches or commits when initializing components     |

--- a/en/pe-docs/docs/references/faq.md
+++ b/en/pe-docs/docs/references/faq.md
@@ -36,7 +36,7 @@ If you have a log monitoring product or service, such as Azure Monitor, you can 
 Choreo allows a maximum request payload size of 50 MB.
 
 ### Q: What source control software does Choreo support?
-Choreo now supports GitHub, Bitbucket and GitLab.
+Choreo now supports GitHub, Bitbucket, GitLab and Azure DevOps.
 
 ### Q: Why don't I see the undeployed builds for my component in Choreo?
 You are allowed to build your component any number of times. However, Choreo has a limit on retaining undeployed builds. For users on the free-tier, Choreo will retain **only one** undeployed build. For those on any other tier, Choreo will retain the **latest five** undeployed builds.

--- a/en/pe-docs/docs/what-is-choreo.md
+++ b/en/pe-docs/docs/what-is-choreo.md
@@ -20,7 +20,7 @@ Choreo is designed to reduce the cognitive and operational load for developers w
 - **Flexible Deployments**: Run Choreo on your existing infrastructure with no vendor lock-in.
 
 ### Application Delivery
-- **Seamless Git Integration**: Native integration with GitHub, BitBucket, and GitLab to support GitOps-based workflows.
+- **Seamless Git Integration**: Native integration with GitHub, BitBucket, GitLab and Azure DevOps to support GitOps-based workflows.
 - **Automated CI/CD Pipelines**: Automates build and deployment pipelines with support for extensions using Argo Workflows.
 - **Secrets & Config Management**: Securely manage secrets, configurations, and configurations for API gateways natively within the platform.
 
@@ -37,7 +37,7 @@ Choreo is designed to reduce the cognitive and operational load for developers w
 
 ### Developer Self-Service Portal
 - **Internal Marketplace**: Provide a centralized hub for developers to discover and reuse existing services and resources  across the organization, fostering collaboration and reuse.
-- **Instant Onboarding**: Connect apps from Git repos (GitHub, GitLab, Bitbucket) or container registries for easy onboarding and CI/CD-driven deployments to any environment.
+- **Instant Onboarding**: Connect apps from Git repos (GitHub, GitLab, Bitbucket, Azure DevOps) or container registries for easy onboarding and CI/CD-driven deployments to any environment.
 - **Self-Service Observability**: Enable teams to access logs, metrics, and insights with built-in access controls, allowing real-time monitoring and issue diagnosis.
 
 ### Unified Portal for Platform Engineers


### PR DESCRIPTION
## Description
> This pull request updates the documentation to reflect support for Azure DevOps as a Git provider in Choreo. It also adds details on how to authorize Choreo using a Personal Access Token (PAT) from Azure DevOps and clarifies the permissions required. The changes ensure that all relevant documentation consistently lists Azure DevOps alongside GitHub, Bitbucket, and GitLab.

**Documentation updates for Azure DevOps support:**

* Updated references to supported Git providers throughout the documentation to include Azure DevOps in addition to GitHub, Bitbucket, and GitLab (`develop-components-with-git.md`, `set-up-git-provider-authentication-for-choreo-deployments.md`, `faq.md`, `what-is-choreo.md`). [[1]](diffhunk://#diff-6abecf70a0f343cf3d7085ed61b676473570668cbdb49f56a07947cfd8dcb37bL3-R3) [[2]](diffhunk://#diff-2f201ae1e19ab8c4aa4546777321dae93a18b11c61fd40586e5429c81a9f99a2L39-R39) [[3]](diffhunk://#diff-7d008ddb5bc6a461306f899943b13d98ccee4891b2c8909b0d12fa406d15cd61L24-R24) [[4]](diffhunk://#diff-ff3da5b3cbdcbf157a26c1bd5182980bb3fc040e046ba6042984319e2dfe5937L3-R3) [[5]](diffhunk://#diff-da378851f3ccfbef2d971facc11c985af3fa54e2a3ad274850d506a5765b53f7L39-R39) [[6]](diffhunk://#diff-000efbc73eaf14c1895d27a4e9f9a4bcda5367351c94e0a3a25ddbef8950021eL23-R23) [[7]](diffhunk://#diff-000efbc73eaf14c1895d27a4e9f9a4bcda5367351c94e0a3a25ddbef8950021eL40-R40)

**Authorization and setup instructions:**

* Added sections describing how to authorize Azure DevOps with Choreo using a Personal Access Token (PAT), including a table outlining the required permissions for project, team, and code access (`develop-components-with-git.md`, `set-up-git-provider-authentication-for-choreo-deployments.md`). [[1]](diffhunk://#diff-6abecf70a0f343cf3d7085ed61b676473570668cbdb49f56a07947cfd8dcb37bR107-R116) [[2]](diffhunk://#diff-ff3da5b3cbdcbf157a26c1bd5182980bb3fc040e046ba6042984319e2dfe5937R52-R61)
* Updated instructions for connecting repositories to Choreo to mention Azure DevOps as a supported option for PAT-based authentication (`set-up-git-provider-authentication-for-choreo-deployments.md`).

Related issue - https://github.com/wso2-enterprise/choreo/issues/38332
## Type of change

- [ ] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [x] Change is applicable for both Developer and Platform Engineer views

## Testing

- [ ] Change is tested in Developer view
- [ ] Change is tested in Platform Engineer view

## Related issues
> List related issues here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Azure DevOps as a supported Git provider across docs and feature overviews.
  * Added an authorization guide for Azure DevOps using Personal Access Tokens with required permissions.
  * Updated FAQs and product pages to reflect expanded Git integration.
  * Note: Azure DevOps authorization content appears duplicated in one document.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->