### PR TITLE
docs(choreo): fix typo in Troubleshoot Choreo (default output directory)

### DIFF
--- a/en/developer-docs/docs/references/troubleshoot-choreo.md
+++ b/en/developer-docs/docs/references/troubleshoot-choreo.md
@@ -9,7 +9,7 @@ This page walks you through common problems you may encounter when building and 
       This occurs due to specifying an incorrect build output directory when you set up your Angular application in Choreo.
 To resolve the issue, follow the guidelines given below:
 
-       - Ensure that the build output directory correctly points to where your Angular build script outputs the files. The deafult output directory is `dist/<project-name>`.
+       - Ensure that the build output directory correctly points to where your Angular build script outputs the files. The default output directory is `dist/<project-name>`.
        - Make sure to reconfigure the build settings if the current configuration is incorrect.
 
 - ### An error occurs in the container Trivy scan when building a BYOC component.


### PR DESCRIPTION
What: Fix typo “deafult” → “default”
Where: Troubleshoot Choreo page (Angular build output directory note)
Why: Improves clarity and professionalism for users following troubleshooting steps
Evidence: The live page currently contains “deafult output directory … dist/<project-name>”
Validation: Ran `mkdocs serve` locally
Link to affected page: http://localhost:8000/choreo/docs/references/troubleshoot-choreo/#after-building-a-web-application-the-nginx-welcome-page-is-displayed-instead-of-the-web-application-home-page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typographical error in the troubleshooting guide for Angular build output directory configuration to improve clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->