### PR TITLE
Add metric accuracy considerations section to observability overview

### DIFF
--- a/en/developer-docs/docs/monitoring-and-insights/observability-overview.md
+++ b/en/developer-docs/docs/monitoring-and-insights/observability-overview.md
@@ -40,10 +40,6 @@ Each horizontal section of the graph, termed a *bin*, represents a specific peri
 - **CPU:** CPU usage at the selected time (millicores).
 - **Memory:** Memory usage at the selected time (MiB).
 
-## Metric accuracy considerations
-
-Metrics displayed on the observability dashboard represent point-in-time values rather than continuous measurements. As a result, brief spikes that occur between data collection points may not appear on the graphs. For example, a sudden increase in latency, a short-lived CPU or memory spike, or a burst in throughput may not be fully reflected in the displayed data.
-
 !!! tip
     To get a more detailed view of any metric, narrow the time range on the graph by clicking and dragging the cursor over the period you want to examine. This increases the granularity of the displayed data points and can help reveal anomalies that are not visible in broader time ranges.
 

--- a/en/developer-docs/docs/monitoring-and-insights/observability-overview.md
+++ b/en/developer-docs/docs/monitoring-and-insights/observability-overview.md
@@ -40,6 +40,13 @@ Each horizontal section of the graph, termed a *bin*, represents a specific peri
 - **CPU:** CPU usage at the selected time (millicores).
 - **Memory:** Memory usage at the selected time (MiB).
 
+## Metric accuracy considerations
+
+Metrics displayed on the observability dashboard represent point-in-time values rather than continuous measurements. As a result, brief spikes that occur between data collection points may not appear on the graphs. For example, a sudden increase in latency, a short-lived CPU or memory spike, or a burst in throughput may not be fully reflected in the displayed data.
+
+!!! tip
+    To get a more detailed view of any metric, narrow the time range on the graph by clicking and dragging the cursor over the period you want to examine. This increases the granularity of the displayed data points and can help reveal anomalies that are not visible in broader time ranges.
+
 ## Logs
 
 The **Logs** pane serves as a centralized view to observe logs of the components you deploy on Choreo. This facilitates rigorous troubleshooting and analysis.


### PR DESCRIPTION
## Description
> Add metric accuracy considerations section to observability overview

## Type of change

- [x] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [ ] Change is applicable for both Developer and Platform Engineer views

## Testing

- [x] Change is tested in Developer view
- [ ] Change is tested in Platform Engineer view

## Related issues
> https://github.com/wso2-enterprise/choreo/issues/38534


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added tip blocks in the Observability Overview (CPU/Memory) and Diagnostics views recommending narrowing time ranges to increase data granularity and surface anomalies.
  * Retained guidance on metric accuracy, point-in-time values, and potential data gaps between collection points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->