### PR TITLE
[PE] Add certificate management documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ output.txt
 .vscode/
 fil
 
+.venv/

--- a/en/developer-docs/docs/authentication-and-authorization/secure-communication-between-the-choreo-gateway-and-your-backend-with-mutual-tls.md
+++ b/en/developer-docs/docs/authentication-and-authorization/secure-communication-between-the-choreo-gateway-and-your-backend-with-mutual-tls.md
@@ -10,12 +10,12 @@ Mutual TLS authentication involves both the client and server validating each ot
 
 To establish secure connectivity between the Choreo Gateway and your backend using mutual TLS, you must add the certificate of the backend (server certificate) to Choreo and add the certificate of Choreo (client certificate) as a trusted certificate in the backend.
 
-### Step 1: Configure the backend certificate 
+### Step 1: Configure the backend certificate
 
 #### Prerequisites
 
-- The endpoint must be protected with TLS. 
-- The public certificate of the backend server should be extracted in PEM format and saved on the disk with the `.pem` extension.
+- The endpoint must be protected with TLS.
+- The public certificate of the backend server must be added to {{ product_name }} at the organization level. To add a certificate, see [Manage Certificates](../devops-and-ci-cd/manage-certificates.md).
 
 To configure the backend certificate, follow the steps given below:
 
@@ -23,7 +23,7 @@ To configure the backend certificate, follow the steps given below:
 2. In the **Component Listing** pane, click on the API proxy for which you want to configure TLS. For instructions on how to create an API proxy component, see [Develop an API Proxy: Step 1](../develop-components/develop-an-api-proxy.md#step-1-create-an-api-proxy).
 3. In the left navigation menu, click **Develop** and then click **Endpoints**.
 4. On the **Endpoints** page, click **Configure** corresponding to the endpoint.
-5. Click **Upload Endpoint Certificate**, and select the certificate file that you extracted in the prerequisites section to add it. This adds the certificate to all the environments as the default certificate for the endpoint. You can override this certificate if necessary when you deploy or promote the API.
+5. Select the backend certificate from the **Endpoint Certificate** dropdown. This lists all certificates available at the organization level. The selected certificate applies to all environments as the default for the endpoint. You can override this certificate if necessary when you deploy or promote the API.
 
 ### Step 2: Configure mutual TLS with the backend service
 

--- a/en/developer-docs/docs/authentication-and-authorization/secure-communication-between-the-choreo-gateway-and-your-backend-with-mutual-tls.md
+++ b/en/developer-docs/docs/authentication-and-authorization/secure-communication-between-the-choreo-gateway-and-your-backend-with-mutual-tls.md
@@ -15,7 +15,7 @@ To establish secure connectivity between the Choreo Gateway and your backend usi
 #### Prerequisites
 
 - The endpoint must be protected with TLS.
-- The public certificate of the backend server must be added to {{ product_name }} at the organization level. To add a certificate, see [Manage Certificates](../devops-and-ci-cd/manage-certificates.md).
+- The public certificate of the backend server must be added to Choreo at the organization level. To add a certificate, see [Manage Certificates](../devops-and-ci-cd/manage-certificates.md).
 
 To configure the backend certificate, follow the steps given below:
 

--- a/en/developer-docs/docs/devops-and-ci-cd/configure-certificates-for-proxies.md
+++ b/en/developer-docs/docs/devops-and-ci-cd/configure-certificates-for-proxies.md
@@ -1,0 +1,44 @@
+
+# Configure Certificates for Proxies
+
+You can apply organization-level TLS certificates to Proxy components to ensure secure communication with external services. Certificates configured at the organization level are available for selection when configuring Proxy endpoints and during deployment. To learn how to create and manage certificates at the organization level, see [Manage Certificates](./manage-certificates.md).
+
+## Configure endpoint certificates
+
+To configure TLS certificates for a Proxy component's endpoints, follow the steps given below:
+
+1. Navigate to the Proxy component you want to configure.
+2. On the **Endpoints** page, locate the endpoint you want to secure.
+3. Select a TLS/endpoint certificate from the dropdown. The dropdown lists certificates available at the organization level.
+4. Optionally, configure a separate certificate for the sandbox endpoint.
+
+!!! note
+    mTLS certificates follow a different configuration flow. For details, see [Secure Communication Between the Gateway and Your Backend with Mutual TLS](../authentication-and-authorization/secure-communication-between-the-choreo-gateway-and-your-backend-with-mutual-tls.md).
+
+## Deploy a proxy with endpoint certificate
+
+To deploy a Proxy component with an endpoint certificate, follow the steps given below:
+
+1. Navigate to the Proxy component's **Deploy** page.
+2. Click **Configure & Deploy**. This opens the configuration and deployment wizard.
+3. In the wizard, you can select or change TLS certificates for main endpoint and sandbox endpoint.
+4. Click **Save and Deploy** to deploy the component with the selected certificates.
+
+## Promote a proxy with certificate
+
+When promoting a Proxy component from a lower environment to a higher environment, you can change the certificates applied to the component:
+
+1. Navigate to the Proxy component's **Deploy** page.
+2. Click **Promote** on the environment card of the lower environment.
+3. In the promotion wizard, update the endpoint certificates as needed for the target environment.
+4. Complete the promotion.
+
+## Update certificates on a deployed proxy
+
+To update certificates on an already deployed Proxy component, follow the steps given below:
+
+1. Navigate to the Proxy component's **Deploy** page.
+2. On the deployed environment card, click **Environment Variables**.
+3. Click **Endpoint Configuration**.
+4. Click **Update** and select or change the relevant certificate from the dropdown.
+5. Click **Save and Deploy** to redeploy the component for the changes to take effect.

--- a/en/developer-docs/docs/devops-and-ci-cd/configure-certificates-for-services.md
+++ b/en/developer-docs/docs/devops-and-ci-cd/configure-certificates-for-services.md
@@ -1,0 +1,95 @@
+
+# Configure Certificates for Services
+
+You can mount organization-level TLS certificates to Service components to enable secure communication with external services. Certificates configured at the organization level are available for selection when deploying services. To learn how to create and manage certificates at the organization level, see [Manage Certificates](./manage-certificates.md).
+
+!!! info
+    This feature is currently only available for Ballerina, WSO2 MI, Docker, Go, Python, Java, .NET, NodeJS, Ruby, and PHP build presets (excluding Web Applications).
+
+The steps to configure certificates vary depending on the build preset. See the relevant section below:
+
+## Ballerina services
+
+### Deploy a service with certificates
+
+To deploy a Ballerina Service component with certificates, follow the steps given below:
+
+1. Navigate to the Service component's **Deploy** page.
+2. Click **Configure & Deploy**. This opens the configuration form.
+3. Click **Next** to navigate to the **Certificate Mount** page.
+4. Click **Link a Certificate** and specify the following:
+
+    - **Mount Path**: The path where the certificate will be mounted (for example, `/app/`).
+    - **Certificate**: Select the certificate from the dropdown. The dropdown lists certificates available at the organization level.
+
+5. Once the certificate is linked, you can expand it to view details such as the **File Name** and **Certificate Key Name**. You can change the file name if required.
+6. To mount additional certificates, click **Link a Certificate** again and repeat the above steps.
+7. Click **Next** and then click **Deploy** to deploy the component with the linked certificates.
+
+### Promote a service with certificates
+
+When promoting a Ballerina Service component from a lower environment to a higher environment, you can change the certificates applied to the component:
+
+1. Navigate to the Service component's **Deploy** page.
+2. Click **Promote** on the environment card of the lower environment.
+3. In the promotion wizard, update the certificate configuration as needed for the target environment.
+4. Complete the promotion.
+
+### Update certificates on a deployed service
+
+To update, link new certificates or unlink certificates on an already deployed Ballerina Service component, follow the steps given below:
+
+1. Navigate to the Service component's **Deploy** page.
+2. On the deployed environment card, click **Configurables**.
+3. In the **Configurations** window that opens, click **Next** to navigate to the certificate mount page.
+4. From here you can:
+
+    - Link a new certificate by clicking **Link Certificate** and specifying the mount path and certificate.
+    - Update an existing certificate mount path or certificate file name.
+    - Unlink a certificate by removing it from the list.
+
+5. Click **Update** to apply the changes.
+
+## Other services
+
+This section applies to WSO2 MI, Docker, Go, Python, Java, .NET, NodeJS, Ruby, and PHP build presets (excluding Web Applications).
+
+### Deploy a service with certificates
+
+To deploy a Service component with certificates, follow the steps given below:
+
+1. Navigate to the Service component's **Deploy** page.
+2. Click **Configure & Deploy**. This opens the configuration form.
+3. Click **Next** to navigate to the **File and Certificate Mount** page.
+4. Click **Link a Certificate** and specify the following:
+
+    - **Mount Path**: The path where the certificate will be mounted (for example, `/app/`).
+    - **Certificate**: Select the certificate from the dropdown. The dropdown lists certificates available at the organization level.
+
+5. Once the certificate is linked, you can expand it to view details such as the **File Name** and **Certificate Key Name**. You can change the file name if required.
+6. To mount additional certificates, click **Link a Certificate** again and repeat the above steps.
+7. Click **Next** and then click **Deploy** to deploy the component with the linked certificates.
+
+### Promote a service with certificates
+
+When promoting a Service component from a lower environment to a higher environment, you can change the certificates applied to the component:
+
+1. Navigate to the Service component's **Deploy** page.
+2. Click **Promote** on the environment card of the lower environment.
+3. In the promotion wizard, update the certificate configuration as needed for the target environment.
+4. Complete the promotion.
+
+### Update certificates on a deployed service
+
+To update, link new certificates or unlink certificates on an already deployed Service component, follow the steps given below:
+
+1. Navigate to the Service component's **Deploy** page.
+2. On the deployed environment card, click **Manage Configs and Secrets**.
+3. Expand the **File and Certificate Mount** section.
+4. From here you can:
+
+    - Link a new certificate by clicking **Link a Certificate** and specifying the mount path and certificate.
+    - Update an existing certificate mount path or certificate file name.
+    - Unlink a certificate by removing it from the list.
+
+5. Click **Save and Deploy** to apply the changes.

--- a/en/developer-docs/docs/devops-and-ci-cd/manage-certificates.md
+++ b/en/developer-docs/docs/devops-and-ci-cd/manage-certificates.md
@@ -1,0 +1,70 @@
+
+# Manage Certificates
+
+{{ product_name }} provides centralized certificate management at the organization level, allowing you to manage TLS certificates and apply them to components during deployment. This ensures secure communication between your components and external services by maintaining trusted certificates in a single place.
+
+## Create a certificate
+
+!!! important
+    - To create certificates, you need `Create Global Configs` or `Manage Global Configs` permission.
+
+To create a new certificate, follow the steps given below:
+
+1. In the [{{ product_name }} Console](https://console.choreo.dev/), go to the top navigation menu. Click **Organization** and select your organization.
+2. In the left navigation menu, click **DevOps** and then click **Certificates**.
+3. On the **Certificates Management** page, click **+ Create Certificate**.
+4. On the **Add a Certificate** page, choose why you're adding the certificate:
+
+    - **Verify External Server**: Use a public certificate to confirm another server's identity for secure TLS connections.
+    - **Secure Website Domain** *(Coming Soon)*: Use SSL/TLS to safely secure your custom domains managed through {{ product_name }}.
+
+5. Specify the following details:
+
+    - **Certificate Name**: A name for the certificate.
+    - **Description**: A description for the certificate (optional).
+    - **Certificate File**: Upload the certificate file in `.pem` format.
+
+6. Click **Add**.
+
+## View certificates
+
+!!! important
+    - To view certificates, you need `View Global Configs` permission.
+
+To view the certificates in your organization, follow the steps given below:
+
+1. In the [{{ product_name }} Console](https://console.choreo.dev/), go to the top navigation menu. Click **Organization** and select your organization.
+2. In the left navigation menu, click **DevOps** and then click **Certificates**.
+3. The **Certificates Management** page lists all certificates in the organization with the following details:
+
+    - **Identifier**: The name of the certificate.
+    - **Type**: The certificate type (for example, Public Cert).
+    - **Validity**: The remaining validity period (for example, Expires in 277 days).
+    - **Action**: Options to manage the certificate, including delete.
+
+4. Click a certificate to view its **Metadata** tab, which includes details such as expiry date, issuer, subject, and fingerprints.
+
+### View certificate usage
+
+A certificate can be used by multiple components across different projects within your organization. The **Usage** tab provides visibility into all components and the relevant environments that reference the selected certificate.
+
+To view certificate usage:
+
+1. Select a certificate from the list.
+2. Click the **Usage** tab.
+3. The tab displays all components using the certificate and the environments they are used in.
+
+## Delete a certificate
+
+!!! important
+    - To delete certificates, you need `Delete Global Configs` or `Manage Global Configs` permission.
+
+To delete a certificate, follow the steps given below:
+
+!!! warning
+    Deleting a certificate is a permanent action. Ensure that the certificate is not in use by any component before deleting it.
+
+1. In the [{{ product_name }} Console](https://console.choreo.dev/), go to the top navigation menu. Click **Organization** and select your organization.
+2. In the left navigation menu, click **DevOps** and then click **Certificates**.
+3. In the **Certificates** list, click the delete icon next to the certificate you want to delete. This will display a confirmation dialog with details about the impact of the deletion.
+4. Review the details and confirm the deletion.

--- a/en/developer-docs/docs/devops-and-ci-cd/manage-certificates.md
+++ b/en/developer-docs/docs/devops-and-ci-cd/manage-certificates.md
@@ -1,7 +1,7 @@
 
 # Manage Certificates
 
-{{ product_name }} provides centralized certificate management at the organization level, allowing you to manage TLS certificates and apply them to components during deployment. This ensures secure communication between your components and external services by maintaining trusted certificates in a single place.
+Choreo provides centralized certificate management at the organization level, allowing you to manage TLS certificates and apply them to components during deployment. This ensures secure communication between your components and external services by maintaining trusted certificates in a single place.
 
 ## Create a certificate
 
@@ -10,13 +10,13 @@
 
 To create a new certificate, follow the steps given below:
 
-1. In the [{{ product_name }} Console](https://console.choreo.dev/), go to the top navigation menu. Click **Organization** and select your organization.
+1. In the [Choreo Console](https://console.choreo.dev/), go to the top navigation menu. Click **Organization** and select your organization.
 2. In the left navigation menu, click **DevOps** and then click **Certificates**.
 3. On the **Certificates Management** page, click **+ Create Certificate**.
 4. On the **Add a Certificate** page, choose why you're adding the certificate:
 
     - **Verify External Server**: Use a public certificate to confirm another server's identity for secure TLS connections.
-    - **Secure Website Domain** *(Coming Soon)*: Use SSL/TLS to safely secure your custom domains managed through {{ product_name }}.
+    - **Secure Website Domain** *(Coming Soon)*: Use SSL/TLS to safely secure your custom domains managed through Choreo.
 
 5. Specify the following details:
 
@@ -33,7 +33,7 @@ To create a new certificate, follow the steps given below:
 
 To view the certificates in your organization, follow the steps given below:
 
-1. In the [{{ product_name }} Console](https://console.choreo.dev/), go to the top navigation menu. Click **Organization** and select your organization.
+1. In the [Choreo Console](https://console.choreo.dev/), go to the top navigation menu. Click **Organization** and select your organization.
 2. In the left navigation menu, click **DevOps** and then click **Certificates**.
 3. The **Certificates Management** page lists all certificates in the organization with the following details:
 
@@ -64,7 +64,7 @@ To delete a certificate, follow the steps given below:
 !!! warning
     Deleting a certificate is a permanent action. Ensure that the certificate is not in use by any component before deleting it.
 
-1. In the [{{ product_name }} Console](https://console.choreo.dev/), go to the top navigation menu. Click **Organization** and select your organization.
+1. In the [Choreo Console](https://console.choreo.dev/), go to the top navigation menu. Click **Organization** and select your organization.
 2. In the left navigation menu, click **DevOps** and then click **Certificates**.
 3. In the **Certificates** list, click the delete icon next to the certificate you want to delete. This will display a confirmation dialog with details about the impact of the deletion.
 4. Review the details and confirm the deletion.

--- a/en/developer-docs/mkdocs.yml
+++ b/en/developer-docs/mkdocs.yml
@@ -184,6 +184,10 @@ nav:
       - Configure Storage: devops-and-ci-cd/configure-storage.md
       - Manage Environments: devops-and-ci-cd/manage-environments.md
       - Manage Configuration Groups: devops-and-ci-cd/manage-configuration-groups.md
+      - Manage Certificates:
+          - Manage Certificates: devops-and-ci-cd/manage-certificates.md
+          - Configure Certificates for Proxies: devops-and-ci-cd/configure-certificates-for-proxies.md
+          - Configure Certificates for Services: devops-and-ci-cd/configure-certificates-for-services.md
       - Manage Continuous Deployment Pipelines: devops-and-ci-cd/manage-continuous-deployment-pipelines.md
       - Configure VPNs on the Choreo Cloud Data Plane: devops-and-ci-cd/configure-vpns-on-the-choreo-cloud-data-plane.md
   - Testing:


### PR DESCRIPTION
## Description
- Add org-level certificate management docs (create, view, delete, usage)
- Add certificate configuration docs for Proxy components
- Add certificate configuration docs for Service components (Ballerina and other presets)
- Update mutual TLS doc to reference org-level certificate management
- Add navigation entries under DevOps > Manage Certificates

## Type of change

- [ ] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [x] Change is applicable for both Developer and Platform Engineer views

## Testing

- [ ] Change is tested in Developer view
- [ ] Change is tested in Platform Engineer view


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated gitignore to ignore the project's virtual environment directory.

* **Documentation**
  * Added comprehensive guides for centralized certificate management at the organization level.
  * Added documentation for configuring TLS certificates for Proxy and Service components.
  * Updated mutual TLS configuration to use a dropdown-based certificate selection flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->