### PR TITLE
[product-rename] Update Ballerina component configuration sections to allow configuration group linking

### DIFF
--- a/en/developer-docs/docs/develop-components/use-configuration-form.md
+++ b/en/developer-docs/docs/develop-components/use-configuration-form.md
@@ -1,7 +1,7 @@
 {{ product_name }} allows you to inject values for your configurations through a rich user interface.
 
 !!! info
-    - This feature is currently only available for Go, Python, Java, .NET, NodeJs, Ruby and PHP build presets (excluding Web Applications).
+    - This feature is currently only available for Ballerina, Go, Python, Java, .NET, NodeJs, Ruby and PHP build presets (excluding Web Applications).
     - The configuration form is supported starting from component.yaml v1.2.
 
 You can configure configurations in the [component.yaml](./manage-component-source-configurations.md). Based on these configurations, a form is displayed in the {{ product_name }} console. Users can define environment variables and file keys under the `configurations` section in the component.yaml.

--- a/en/developer-docs/docs/devops-and-ci-cd/manage-configuration-groups.md
+++ b/en/developer-docs/docs/devops-and-ci-cd/manage-configuration-groups.md
@@ -9,7 +9,7 @@ Configuration groups can be defined at organization level and link to components
     - All configuration group values are encrypted and stored in environment-specific key vaults.
     - Management of configuration groups is restricted to users with {{ product_name }} Admin, DevOps, and Platform Engineer roles.
     - Developers can discover configuration groups available within the organization via the **{{ product_name }} Internal Marketplace**.
-    - This feature is currently not supported for Ballerina build presets, Web Applications, or Test Runner components.
+    - This feature is currently not supported for Web Applications or Test Runner components.
 
 ## Create a configuration group
 
@@ -41,6 +41,9 @@ To create a new configuration group, follow the steps given below:
 The configuration groups created at organization level can be linked to any component within the organization. A configuration group can be linked as **Environment Variables** or **File Mounts** at deployment time.
 
 Linking a configuration group will inject the values defined in the group during deployment. The values are mapped to environment variable names or file names based on the keys defined in the configuration group. If needed, you can customize the environment variable name or file name by updating the mapping at deployment.
+
+!!! note
+      To link configuration groups to Ballerina component configurables, click **Allow Linking Configuration Groups** at the top of the configuration form during deployment. This enables a link icon next to each configurable field, allowing you to map configuration group values.
 
 To link a configuration group to a component, follow the steps given below:
 

--- a/en/developer-docs/docs/devops-and-ci-cd/manage-configurations-and-secrets.md
+++ b/en/developer-docs/docs/devops-and-ci-cd/manage-configurations-and-secrets.md
@@ -89,6 +89,9 @@ You can modify Ballerina configurables via the **Deploy** page when deploying or
       Use configurables instead of environment variables to add file mounts to Ballerina components.
       Environment variables are primarily for components written in other languages.
 
+!!! note
+      To link configuration groups to Ballerina configurables, click **Allow Linking Configuration Groups** at the top of the configuration form during deployment. This enables a link icon next to each configurable field, allowing you to map configuration group values.
+
 ## Alternative configuration management approach
 
 !!! Warning "Warning"

--- a/en/pe-docs/docs/devops/manage-configuration-groups.md
+++ b/en/pe-docs/docs/devops/manage-configuration-groups.md
@@ -9,7 +9,7 @@ Configuration groups can be defined at organization level and link to components
     - All configuration group values are encrypted and stored in environment-specific key vaults.
     - Management of configuration groups is restricted to users with {{ product_name }} Admin, DevOps, and Platform Engineer roles.
     - Developers can discover configuration groups available within the organization via the **{{ product_name }} Internal Marketplace**.
-    - This feature is currently not supported for Ballerina build presets, Web Applications, or Test Runner components.
+    - This feature is currently not supported for Web Applications or Test Runner components.
 
 ## Create a configuration group
 
@@ -42,6 +42,9 @@ To create a new configuration group, follow the steps given below:
 The configuration groups created at organization level can be linked to any component within the organization. A configuration group can be linked as **Environment Variables** or **File Mounts** at deployment time.
 
 Linking a configuration group will inject the values defined in the group during deployment. The values are mapped to environment variable names or file names based on the keys defined in the configuration group. If needed, you can customize the environment variable name or file name by updating the mapping at deployment.
+
+!!! note
+      To link configuration groups to Ballerina component configurables, click **Allow Linking Configuration Groups** at the top of the configuration form during deployment. This enables a link icon next to each configurable field, allowing you to map configuration group values.
 
 To link a configuration group to a component, follow the steps given below:
 

--- a/en/pe-docs/docs/k8s-operations/manage-configurations-and-secrets.md
+++ b/en/pe-docs/docs/k8s-operations/manage-configurations-and-secrets.md
@@ -89,6 +89,9 @@ You can modify Ballerina configurables via the **CD Pipelines** page when deploy
       Use configurables instead of environment variables to add file mounts to Ballerina components.
       Environment variables are primarily for components written in other languages.
 
+!!! note
+      To link configuration groups to Ballerina configurables, click **Allow Linking Configuration Groups** at the top of the configuration form during deployment. This enables a link icon next to each configurable field, allowing you to map configuration group values.
+
 ## Alternative configuration management approach
 
 !!! Warning "Warning"


### PR DESCRIPTION
## Description
> [product-rename] Update Ballerina component configuration sections to allow configuration group linkingt

 Resolves https://github.com/wso2-enterprise/choreo/issues/38695
