### PR TITLE
Downgrade setuptools from 82.0.0 to 81.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - run: |
           echo "Installing Python dependencies"
           pip install --upgrade pip  # Ensure pip is up-to-date
-          pip install setuptools==82.0.0
+          pip install setuptools==81.0.0
           pip install zipp==3.0.0
           pip install pathlib2==2.3.5
           pip install -U --upgrade mkdocs==1.4.2


### PR DESCRIPTION
The package pkg_resources is required by mkdocs but has been removed from latest 82.0.0 version of setuptools, therefore we need to downgrade to use 81.0.0 version of setuptools.

## Description
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

## Type of change

- [ ] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [x] Change is applicable for both Developer and Platform Engineer views

## Testing

- [ ] Change is tested in Developer view
- [ ] Change is tested in Platform Engineer view

## Related issues
> List related issues here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI build configuration with minor dependency version adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->