### PR TITLE
Fix choreo cli application and build logs command examples

### DIFF
--- a/en/developer-docs/docs/choreo-cli/get-started-with-the-choreo-cli.md
+++ b/en/developer-docs/docs/choreo-cli/get-started-with-the-choreo-cli.md
@@ -123,7 +123,7 @@ choreo describe build <build-id> --project="web-app-project" --component="my-web
 Once the build is complete, you can view the build logs for verification or debugging purposes. In the unlikely case, the build encounters any issues, the logs will help you troubleshoot.
 
 ``` sh
-choreo logs --type=build --project="web-app-project" --component="my-web-app" --deployment-track="main" --build-id=<build_id>
+choreo logs build --project="web-app-project" --component="my-web-app" --deployment-track="main" --build-id=<build_id>
 ```
 
 ## Step 6: Deploy to the Development environment
@@ -147,7 +147,7 @@ choreo describe component "my-web-app" --project="web-app-project"
 To observe runtime application logs of the web application in the Development environment, execute the following command:
 
 ``` sh
-choreo logs --type component-application --component my-web-app --project web-app-project --env Development --follow
+choreo logs application --component my-web-app --project web-app-project --env Development --follow
 ```
 
 ## Step 7: Deploy to the Production environment

--- a/en/pe-docs/docs/choreo-cli/get-started-with-the-choreo-cli.md
+++ b/en/pe-docs/docs/choreo-cli/get-started-with-the-choreo-cli.md
@@ -144,7 +144,7 @@ choreo describe build <build-id> --project="web-app-project" --component="my-web
 Once the build is complete, you can view the build logs for verification or debugging purposes. In the unlikely case, the build encounters any issues, the logs will help you troubleshoot.
 
 ``` sh
-choreo logs --type=build --project="web-app-project" --component="my-web-app" --deployment-track="main" --build-id=<build_id>
+choreo logs build --project="web-app-project" --component="my-web-app" --deployment-track="main" --build-id=<build_id>
 ```
 
 ## Step 7: Deploy to the Development environment
@@ -168,7 +168,7 @@ choreo describe component "my-web-app" --project="web-app-project"
 To observe runtime application logs of the web application in the Development environment, execute the following command:
 
 ``` sh
-choreo logs --type component-application --component my-web-app --project web-app-project --env Development --follow
+choreo logs application --component my-web-app --project web-app-project --env Development --follow
 ```
 
 ## Step 8: Deploy to the Production environment


### PR DESCRIPTION
## Description
Fix choreo cli application and build logs command

## Type of change

- [ ] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [x] Change is applicable for both Developer and Platform Engineer views

## Testing

- [x] Change is tested in Developer view
- [x] Change is tested in Platform Engineer view

## Related issues
> List related issues here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Choreo CLI documentation to reflect changes in the logs command syntax. The logs command now uses positional subcommands instead of the --type flag for viewing different log types (e.g., `choreo logs build` instead of `choreo logs --type=build`; `choreo logs application` instead of `choreo logs --type component-application`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->