### PR TITLE
Remove unwanted additonal text on header of PE view

### DIFF
--- a/en/theme/material/templates/pe-home-page.html
+++ b/en/theme/material/templates/pe-home-page.html
@@ -16,7 +16,6 @@
     <a href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}" title="{{ config.site_name | e }}" class="md-header__button md-logo" aria-label="{{ config.site_name }}" data-md-component="logo">
       {% include "partials/logo.html" %}
     </a>
-    <div class="md-header__tabs" style="font-size: 0.875rem; font-weight: normal; white-space: nowrap; padding-right: 1rem; color: black;">{{ config.extra.short_name }} Documentation</div>
     <label class="md-header__button md-icon" for="__drawer">
       {% include ".icons/material/menu" ~ ".svg" %}
     </label>


### PR DESCRIPTION
## Description
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

## Type of change

- [ ] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [x] Change is applicable for both Developer and Platform Engineer views

## Testing

- [ ] Change is tested in Developer view
- [ ] Change is tested in Platform Engineer view

## Related issues
> List related issues here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the "Documentation" label from the page header, streamlining the header interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->