### PR TITLE
Fix typos and formatting issues in limitations, approvals, and mkdocs config

### DIFF
--- a/en/developer-docs/docs/administer/configure-approvals-for-choreo-workflows.md
+++ b/en/developer-docs/docs/administer/configure-approvals-for-choreo-workflows.md
@@ -63,7 +63,7 @@ To set up an approval process for a workflow, follow these steps:
     Both Roles and Assignees are optional configuration fields. If neither is specified, the system will not dispatch any notifications. However, users with the necessary permissions can still log in to the system and review approval requests through the interface.
 
     !!! info "Important"
-         Only roles having [relevant approval permission](#permissions-to-review-and-respond-to-approval-requests) can be selected to receive notifications, so that respective users can always review and respond to requests. However, users in Assignees field are there for notification purpose only, they may not have required priviledges to review and approve requests.
+         Only roles having [relevant approval permission](#permissions-to-review-and-respond-to-approval-requests) can be selected to receive notifications, so that respective users can always review and respond to requests. However, users in Assignees field are there for notification purpose only, they may not have required privileges to review and approve requests.
 
 
 7. Click **Save**. This configures notifications and enables the approval process for the workflow.

--- a/en/developer-docs/docs/references/choreo-limitations.md
+++ b/en/developer-docs/docs/references/choreo-limitations.md
@@ -12,9 +12,9 @@ Below are key limitations when working with APIs in {{ product_name }}:
 | URL size                            |  2 KB                                                                                       |
 | Request header                      | <ul><li>Request Headers total: 40 KB</li><li>Max Single Request header: 10 KB</li></ul>     |
 | Total request duration              | <ul><li>Minimum: 10 seconds</li><li>Default: 1 minute</li><li>Maximum: 5 minutes</li></ul>  |
-| Maximum connection duration (WebSocket APIs)  |  15  minutes                                                                      |
+| Maximum connection duration (WebSocket APIs)  |  15 minutes                                                                       |
 | Connection idle timeout (WebSocket APIs)                            |  5 minutes                                                  |
-| Size for API definition (OpenAPI document)| 10 Mb                                                                                 |
+| Size for API definition (OpenAPI document)| 10 MB                                                                                 |
 | Number of APIs for PDP                 | 1000 API deployments                                                                     |
 | Number of APIs per organization (free tier)                 | 5 APIs for free users                                               |
 | Number of Developer Portal applications per organization (free tier)  | 10 applications for free users                            |

--- a/en/developer-docs/mkdocs.yml
+++ b/en/developer-docs/mkdocs.yml
@@ -16,7 +16,7 @@
 
 # Project information
 site_name: "WSO2 Developer Platform Documentation | AI-Native Internal Developer Platform"
-site_description: WSO2 Developer Platform Explore WSO2 Developer Platform documentation to build, deploy, and manage cloud-native apps effortlessly. Whether you're a platform engineer or app developer, WSO2 Developer Platform simplifies infrastructure automation and streamlines delivery with an AI-native internal developer platform.
+site_description: WSO2 Developer Platform. Explore WSO2 Developer Platform documentation to build, deploy, and manage cloud-native apps effortlessly. Whether you're a platform engineer or app developer, WSO2 Developer Platform simplifies infrastructure automation and streamlines delivery with an AI-native internal developer platform.
 site_author: WSO2
 site_url: https://wso2.com/choreo/docs
 site_dir: site/developer

--- a/en/pe-docs/docs/references/choreo-limitations.md
+++ b/en/pe-docs/docs/references/choreo-limitations.md
@@ -12,9 +12,9 @@ Below are key limitations when working with APIs in {{ product_name }}:
 | URL size                            |  2 KB                                                                                       |
 | Request header                      | <ul><li>Request Headers total: 40 KB</li><li>Max Single Request header: 10 KB</li></ul>     |
 | Total request duration              | <ul><li>Minimum: 10 seconds</li><li>Default: 1 minute</li><li>Maximum: 5 minutes</li></ul>  |
-| Maximum connection duration (WebSocket APIs)  |  15  minutes                                                                      |
+| Maximum connection duration (WebSocket APIs)  |  15 minutes                                                                       |
 | Connection idle timeout (WebSocket APIs)                            |  5 minutes                                                  |
-| Size for API definition (OpenAPI document)| 10 Mb                                                                                 |
+| Size for API definition (OpenAPI document)| 10 MB                                                                                 |
 | Number of APIs for PDP                 | 1000 API deployments                                                                     |
 | Number of APIs per organization (free tier)                 | 5 APIs for free users                                               |
 | Number of Developer Portal applications per organization (free tier)  | 10 applications for free users                            |

--- a/en/pe-docs/mkdocs.yml
+++ b/en/pe-docs/mkdocs.yml
@@ -16,7 +16,7 @@
 
 # Project information
 site_name: "WSO2 Developer Platform Documentation | AI-Native Internal Developer Platform"
-site_description: WSO2 Developer Platform Explore WSO2 Developer Platform documentation to build, deploy, and manage cloud-native apps effortlessly. Whether you're a platform engineer or app developer, WSO2 Developer Platform simplifies infrastructure automation and streamlines delivery with an AI-native internal developer platform.
+site_description: WSO2 Developer Platform. Explore WSO2 Developer Platform documentation to build, deploy, and manage cloud-native apps effortlessly. Whether you're a platform engineer or app developer, WSO2 Developer Platform simplifies infrastructure automation and streamlines delivery with an AI-native internal developer platform.
 site_author: WSO2
 site_url: https://wso2.com/choreo/docs
 site_dir: site/platform-engineer


### PR DESCRIPTION
## Summary

- Fix double space: `15  minutes` → `15 minutes` in `choreo-limitations.md` (developer-docs and pe-docs)
- Fix unit typo: `10 Mb` → `10 MB` in `choreo-limitations.md` (developer-docs and pe-docs)
- Fix spelling: `priviledges` → `privileges` in `configure-approvals-for-choreo-workflows.md`
- Fix missing period in `site_description` in `mkdocs.yml` (developer-docs and pe-docs)

## Testing
- [x] Verified all changes are accurate
- [x] No new issues introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed spelling errors and formatting inconsistencies across documentation
  * Corrected API management limits reference table formatting and units
  * Improved site description formatting for better readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->