### PR TITLE
Fix inconsistent documentation on API minor version behavior

### DIFF
--- a/en/developer-docs/docs/api-management/lifecycle-management.md
+++ b/en/developer-docs/docs/api-management/lifecycle-management.md
@@ -20,12 +20,12 @@ The following lifecycle states are applicable to APIs in {{ product_name }}:
 
 When you create a new version of an API, it directly affects the lifecycle state of existing versions:
 
-- **Minor version upgrades** (e.g., v1.0 → v1.1): When a new minor version is published, it becomes the default version shown in the Developer Portal under that major version. The previous minor version remains accessible and can be invoked using its version-specific endpoint URL.
+- **Minor version upgrades** (e.g., v1.0 → v1.1): when a new minor version is published, it becomes the default version for its corresponding major version. The Developer Portal displays the latest minor version (for example, v1.1) as the primary API under that major version (v1), and the /v1 endpoint resolves to this version.
 
 - **Major version upgrades** (e.g., v1 → v2): Both major versions appear as **separate entries** in the Developer Portal. The older major version remains in its current lifecycle state and is not automatically deprecated.
 
 !!! note
-    If you need to invoke an older minor version, you can use the endpoint URL with the specific minor version (e.g., `/v1.0` instead of `/v1`).
+    Previously published minor versions (for example, v1.0) remain accessible via their version-specific endpoints (for example, /v1.0) and continue to be available until they are explicitly deprecated or retired through the API lifecycle management process.
 
 ## Manage the lifecycle of an API
 

--- a/en/developer-docs/docs/api-management/lifecycle-management.md
+++ b/en/developer-docs/docs/api-management/lifecycle-management.md
@@ -13,7 +13,7 @@ The following lifecycle states are applicable to APIs in {{ product_name }}:
 | **CREATED** | The API is created but is not ready for consumption.| The API is not visible to subscribers in the Developer Portal.|
 | **PRE-RELEASED** | A prototype is created for early promotion and consumer testing. You can deploy a new API or a new version of an existing API as a prototype to provide subscribers with an early implementation of the API.|The API is published to the Developer Portal as a pre-release.|
 | **PUBLISHED** | The API is ready for subscribers to view and subscribe to via the Developer Portal| The API is visible in the Developer Portal and is available for subscription.|
-| **DEPRECATED** | An API version enters this state when it is explicitly deprecated, or automatically when a newer **minor** version under the same major version is published.| The API is deployed and is available to existing subscribers. New subscriptions are disabled. Existing subscribers can continue to use it as usual until the API is retired. **Note:** Deprecation is irreversible. A deprecated API cannot be moved back to the Published state (see [Versioning impact on API lifecycle](#versioning-impact-on-api-lifecycle)).|
+| **DEPRECATED** | The API is nearing the end of its lifecycle and is being phased out of use.| The API remains accessible to existing subscribers, but new subscriptions are disabled in the Developer Portal. **Note**: Deprecation is irreversible and cannot be reverted to the Published state.|
 | **RETIRED** | The API is no longer in use when it is in this state.| The API is unpublished and deleted from the Developer Portal.|
 
 ## Versioning impact on API lifecycle

--- a/en/developer-docs/docs/api-management/lifecycle-management.md
+++ b/en/developer-docs/docs/api-management/lifecycle-management.md
@@ -20,12 +20,12 @@ The following lifecycle states are applicable to APIs in {{ product_name }}:
 
 When you create a new version of an API, it directly affects the lifecycle state of existing versions:
 
-- **Minor version upgrades** (e.g., v1.0 → v1.1): Publishing the new minor version automatically **deprecates** the previous minor version under the same major version. The deprecated version is replaced in the Developer Portal. Only the latest minor version is visible. This action is **irreversible** — the previous minor version cannot be restored to the Published state.
+- **Minor version upgrades** (e.g., v1.0 → v1.1): When a new minor version is published, it becomes the default version shown in the Developer Portal under that major version. The previous minor version remains accessible and can be invoked using its version-specific endpoint URL.
 
 - **Major version upgrades** (e.g., v1 → v2): Both major versions appear as **separate entries** in the Developer Portal. The older major version remains in its current lifecycle state and is not automatically deprecated.
 
-!!! warning "Important"
-    Creating a minor version has an irreversible effect on the previous minor version's lifecycle. Before creating a new minor version, ensure you no longer need the previous minor version to be in the Published state. If you need both versions available simultaneously, use a major version upgrade instead.
+!!! note
+    If you need to invoke an older minor version, you can use the endpoint URL with the specific minor version (e.g., `/v1.0` instead of `/v1`).
 
 ## Manage the lifecycle of an API
 


### PR DESCRIPTION
## Description
The existing documentation regarding how minor version upgrades affect the API lifecycle was inconsistent with the actual system behavior.

This PR fixes the discrepancy by aligning the documentation with the acutal behaviour. Specifically, it clarifies that:

- Minor version upgrades do not break or remove access to older versions.
- Previous minor versions remain fully accessible to users via their specific, versioned endpoints.

Before :
<img width="988" height="405" alt="image" src="https://github.com/user-attachments/assets/4c3ab866-bc20-4fe6-999d-c208f54a1940" />


After:
<img width="970" height="428" alt="image" src="https://github.com/user-attachments/assets/84c63a57-16eb-4617-ae3b-29b287836ef6" />


## Issues
https://github.com/wso2-enterprise/choreo/issues/38725
https://github.com/wso2-enterprise/choreo/issues/38772

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified DEPRECATED semantics to describe it as a lifecycle phase indicating a version is being phased out.
  * Clarified minor version upgrade behavior: newly published minor becomes the default/primary under its major; the major-version endpoint (e.g., /v1) resolves to the latest minor.
  * Noted that earlier minor versions remain accessible via version-specific endpoints (e.g., /v1.0) until explicitly deprecated or retired.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->