### PR TITLE
Add cert management feature for BYOI components

### DIFF
--- a/en/developer-docs/docs/devops-and-ci-cd/configure-certificates-for-services.md
+++ b/en/developer-docs/docs/devops-and-ci-cd/configure-certificates-for-services.md
@@ -4,7 +4,7 @@
 You can mount organization-level TLS certificates to Service components to enable secure communication with external services. Certificates configured at the organization level are available for selection when deploying services. To learn how to create and manage certificates at the organization level, see [Manage Certificates](./manage-certificates.md).
 
 !!! info
-    This feature is currently only available for Ballerina, WSO2 MI, Docker, Go, Python, Java, .NET, NodeJS, Ruby, and PHP build presets (excluding Web Applications).
+    This feature is currently only available for Ballerina, WSO2 MI, BYOI, Docker, Go, Python, Java, .NET, NodeJS, Ruby, and PHP build presets (excluding Web Applications).
 
 The steps to configure certificates vary depending on the build preset. See the relevant section below:
 
@@ -52,7 +52,7 @@ To update, link new certificates or unlink certificates on an already deployed B
 
 ## Other services
 
-This section applies to WSO2 MI, Docker, Go, Python, Java, .NET, NodeJS, Ruby, and PHP build presets (excluding Web Applications).
+This section applies to WSO2 MI, BYOI, Docker, Go, Python, Java, .NET, NodeJS, Ruby, and PHP build presets (excluding Web Applications).
 
 ### Deploy a service with certificates
 


### PR DESCRIPTION
## Description
Add cert management feature for BYOI components

## Type of change

- [x] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [ ] Change is applicable for both Developer and Platform Engineer views

## Testing

- [x] Change is tested in Developer view
- [ ] Change is tested in Platform Engineer view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added BYOI to the list of supported build environments for mounting organization-level TLS certificates, now including WSO2 MI, Docker, Go, Python, Java, .NET, NodeJS, Ruby, PHP, and BYOI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->