### PR TITLE
Update choreo docs related to Github Proxy

### DIFF
--- a/en/developer-docs/docs/develop-components/develop-proxy/develop-an-api-proxy-from-a-github-repository-source.md
+++ b/en/developer-docs/docs/develop-components/develop-proxy/develop-an-api-proxy-from-a-github-repository-source.md
@@ -78,7 +78,7 @@ You can create an API proxy either by selecting the source from a GitHub reposit
 8. Click **Create**. This creates the API proxy component and takes you to the **Build** page.
 
     !!! note
-        When you create an API proxy from a GitHub repository source, the GitHub source serves as the single source of truth. Therefore, any modifications, such as adding or deleting resources, must be made through the GitHub repository. 
+        When you create an API proxy from a GitHub repository, the GitHub source serves as the single source of truth. Therefore, any modifications, such as adding or deleting resources, must be made through the GitHub repository. 
         In the above sample, the `component.yaml` file is located in the department-api-proxy-from-github/.choreo/ directory. It is used to define the relative path to the API specification. The workflow reads this path to fetch the Swagger/OpenAPI definition.
         Sample `component.yaml` file : 
 

--- a/en/developer-docs/docs/develop-components/develop-proxy/develop-an-api-proxy-from-a-github-repository-source.md
+++ b/en/developer-docs/docs/develop-components/develop-proxy/develop-an-api-proxy-from-a-github-repository-source.md
@@ -77,8 +77,18 @@ You can create an API proxy either by selecting the source from a GitHub reposit
 
 8. Click **Create**. This creates the API proxy component and takes you to the **Build** page.
 
-!!! note
-    When you create an API proxy from a GitHub repository source, the GitHub source serves as the single source of truth. Therefore, any modifications, such as adding or deleting resources, must be made through the GitHub repository.
+    !!! note
+        When you create an API proxy from a GitHub repository source, the GitHub source serves as the single source of truth. Therefore, any modifications, such as adding or deleting resources, must be made through the GitHub repository. 
+        In the above sample, the `component.yaml` file is located in the department-api-proxy-from-github/.choreo/ directory. It is used to define the relative path to the API specification. The workflow reads this path to fetch the Swagger/OpenAPI definition.
+        Sample `component.yaml` file : 
+
+        ```yaml
+        schemaVersion: 1.2
+        proxy:
+            type: REST
+            schemaFilePath: openapi.yaml
+        ```
+
 
 ## Step 2: Build
 


### PR DESCRIPTION
## Description
> This pull request adds additional documentation to clarify how the `component.yaml` file is used when creating an API proxy from a GitHub repository source. The update provides a sample `component.yaml` file and explains its purpose in defining the path to the API specification.

Documentation improvements:

* Added an explanation that the `component.yaml` file, located in the `.choreo/` directory, defines the relative path to the API specification and is used by the workflow to fetch the Swagger/OpenAPI definition. Included a sample `component.yaml` file for reference.

Related issue - https://github.com/wso2-enterprise/choreo/issues/38720

## Type of change

- [x] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [ ] Change is applicable for both Developer and Platform Engineer views

## Testing

- [ ] Change is tested in Developer view
- [ ] Change is tested in Platform Engineer view

## Related issues
> List related issues here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified repository-sourced API proxy docs to better explain the configuration file location and how it specifies the API definition used by the workflow.
  * Added a sample configuration snippet and reformatted guidance notes for improved readability and comprehension.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->