### PR TITLE
Update certificate docs to use consistent terminology and simplify content

### DIFF
--- a/en/developer-docs/docs/devops-and-ci-cd/configure-certificates-for-proxies.md
+++ b/en/developer-docs/docs/devops-and-ci-cd/configure-certificates-for-proxies.md
@@ -1,7 +1,10 @@
 
 # Configure Certificates for Proxies
 
-You can apply organization-level TLS certificates to Proxy components to ensure secure communication with external services. Certificates configured at the organization level are available for selection when configuring Proxy endpoints and during deployment. To learn how to create and manage certificates at the organization level, see [Manage Certificates](./manage-certificates.md).
+!!! note
+    mTLS certificates follow a different configuration flow. For details, see [Secure Communication Between the Gateway and Your Backend with Mutual TLS](../authentication-and-authorization/secure-communication-between-the-choreo-gateway-and-your-backend-with-mutual-tls.md).
+
+You can apply organization-level TLS certificates to Proxy components to ensure secure communication with external services. Certificates configured at the organization level are available for selection when configuring Proxy endpoints and during deployment. To learn how to add and manage certificates at the organization level, see [Manage Certificates](./manage-certificates.md).
 
 ## Configure endpoint certificates
 
@@ -11,9 +14,6 @@ To configure TLS certificates for a Proxy component's endpoints, follow the step
 2. On the **Endpoints** page, locate the endpoint you want to secure.
 3. Select a TLS/endpoint certificate from the dropdown. The dropdown lists certificates available at the organization level.
 4. Optionally, configure a separate certificate for the sandbox endpoint.
-
-!!! note
-    mTLS certificates follow a different configuration flow. For details, see [Secure Communication Between the Gateway and Your Backend with Mutual TLS](../authentication-and-authorization/secure-communication-between-the-choreo-gateway-and-your-backend-with-mutual-tls.md).
 
 ## Deploy a proxy with endpoint certificate
 

--- a/en/developer-docs/docs/devops-and-ci-cd/configure-certificates-for-services.md
+++ b/en/developer-docs/docs/devops-and-ci-cd/configure-certificates-for-services.md
@@ -1,7 +1,7 @@
 
 # Configure Certificates for Services
 
-You can mount organization-level TLS certificates to Service components to enable secure communication with external services. Certificates configured at the organization level are available for selection when deploying services. To learn how to create and manage certificates at the organization level, see [Manage Certificates](./manage-certificates.md).
+You can mount organization-level TLS certificates to Service components to enable secure communication with external services. Certificates configured at the organization level are available for selection when deploying services. To learn how to add and manage certificates at the organization level, see [Manage Certificates](./manage-certificates.md).
 
 !!! info
     This feature is currently only available for Ballerina, WSO2 MI, BYOI, Docker, Go, Python, Java, .NET, NodeJS, Ruby, and PHP build presets (excluding Web Applications).

--- a/en/developer-docs/docs/devops-and-ci-cd/manage-certificates.md
+++ b/en/developer-docs/docs/devops-and-ci-cd/manage-certificates.md
@@ -1,30 +1,25 @@
 
 # Manage Certificates
 
-{{ product_name }} provides centralized certificate management at the organization level, allowing you to manage TLS certificates and apply them to components during deployment. This ensures secure communication between your components and external services by maintaining trusted certificates in a single place.
+{{ product_name }} provides centralized certificate management at the organization level, allowing you add certificates and apply them to components during deployment.
 
-## Create a certificate
+## Add a certificate
 
 !!! important
-    - To create certificates, you need `Create Global Configs` or `Manage Global Configs` permission.
+    - To add certificates, you need `Create Global Configs` or `Manage Global Configs` permission.
 
-To create a new certificate, follow the steps given below:
+To add a new certificate, follow the steps given below:
 
 1. In the [{{ product_name }} Console](https://console.choreo.dev/), go to the top navigation menu. Click **Organization** and select your organization.
 2. In the left navigation menu, click **DevOps** and then click **Certificates**.
-3. On the **Certificates Management** page, click **+ Create Certificate**.
-4. On the **Add a Certificate** page, choose why you're adding the certificate:
-
-    - **Verify External Server**: Use a public certificate to confirm another server's identity for secure TLS connections.
-    - **Secure Website Domain** *(Coming Soon)*: Use SSL/TLS to safely secure your custom domains managed through {{ product_name }}.
-
-5. Specify the following details:
+3. On the **Certificates Management** page, click **+ Add Certificate**.
+4. On the **Add a Certificate** page, specify the following details:
 
     - **Certificate Name**: A name for the certificate.
     - **Description**: A description for the certificate (optional).
     - **Certificate File**: Upload the certificate file in `.pem` format.
 
-6. Click **Add**.
+5. Click **Add**.
 
 ## View certificates
 

--- a/en/developer-docs/docs/devops-and-ci-cd/manage-certificates.md
+++ b/en/developer-docs/docs/devops-and-ci-cd/manage-certificates.md
@@ -1,7 +1,7 @@
 
 # Manage Certificates
 
-{{ product_name }} provides centralized certificate management at the organization level, allowing you add certificates and apply them to components during deployment.
+{{ product_name }} provides centralized certificate management at the organization level, allowing you to add certificates and apply them to components during deployment.
 
 ## Add a certificate
 


### PR DESCRIPTION
## Description
Update certificate docs to use consistent terminology and simplify content

## Type of change

- [x] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [ ] Change is applicable for both Developer and Platform Engineer views

## Testing

- [x] Change is tested in Developer view
- [x] Change is tested in Platform Engineer view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an upfront note clarifying mutual TLS uses a different configuration flow and linked to mutual TLS docs
  * Removed duplicate mTLS note from the endpoint certificate section
  * Changed wording from “Create” to “Add” across certificate docs, including button/CTA labels
  * Shortened the add-certificate flow by removing the intermediate “reason” selection step, adjusting step numbering and permission text
<!-- end of auto-generated comment: release notes by coderabbit.ai -->