### PR TITLE
Update Choreo documentation to reflect support for build variables in BYOC components

### DIFF
--- a/en/developer-docs/docs/develop-components/deploy-an-application-with-buildpacks.md
+++ b/en/developer-docs/docs/develop-components/deploy-an-application-with-buildpacks.md
@@ -169,9 +169,9 @@ You can configure the environment variables necessary to build the component usi
 For Buildpack components:
 During the build process, the build-time environment variables and their values are passed to the build preset. Therefore, you can configure both build preset-specific environment variables and those required for the component build.
 
-For example, if you want to override the Maven command of the Java build presets, you can use GOOGLE_MAVEN_BUILD_ARGS as the environment key and clean install as the value.
+For example, if you want to override the Maven command of the  **Java** build presets, you can use `GOOGLE_MAVEN_BUILD_ARGS` as the environment key and `clean install` as the value.
 
-For more examples, see Google Cloud's buildpacks documentation.
+For more examples, see [Google Cloud's buildpacks documentation](https://cloud.google.com/docs/buildpacks/service-specific-configs)..
 
 For BYOC (Bring Your Own Container) components:
 You can configure build-time environment variables that are passed as build arguments (ARG) during the Docker image build process. These variables are available during the build stage of your Dockerfile and can be used to customize the build behavior.

--- a/en/developer-docs/docs/develop-components/deploy-an-application-with-buildpacks.md
+++ b/en/developer-docs/docs/develop-components/deploy-an-application-with-buildpacks.md
@@ -166,11 +166,17 @@ Follow the guidelines below based on your language:
 
 You can configure the environment variables necessary to build the component using the **Build Configurations Editor** on the component **Build** page. 
 
+For Buildpack components:
 During the build process, the build-time environment variables and their values are passed to the build preset. Therefore, you can configure both build preset-specific environment variables and those required for the component build.
 
-For example, if you want to override the Maven command of the **Java** build presets, you can use `GOOGLE_MAVEN_BUILD_ARGS` as the environment key and `clean install` as the value. 
+For example, if you want to override the Maven command of the Java build presets, you can use GOOGLE_MAVEN_BUILD_ARGS as the environment key and clean install as the value.
 
-For more examples, see [Google Cloud's buildpacks documentation](https://cloud.google.com/docs/buildpacks/service-specific-configs).
+For more examples, see Google Cloud's buildpacks documentation.
+
+For BYOC (Bring Your Own Container) components:
+You can configure build-time environment variables that are passed as build arguments (ARG) during the Docker image build process. These variables are available during the build stage of your Dockerfile and can be used to customize the build behavior.
+
+For example, you can set environment variables to configure build-specific settings such as build modes, feature flags, or dependency options that your Dockerfile references via ARG directives.
 
 ### Customize the Default Run Command
 

--- a/en/developer-docs/docs/develop-components/deploy-an-application-with-buildpacks.md
+++ b/en/developer-docs/docs/develop-components/deploy-an-application-with-buildpacks.md
@@ -169,7 +169,7 @@ You can configure the environment variables necessary to build the component usi
 For Buildpack components:
 During the build process, the build-time environment variables and their values are passed to the build preset. Therefore, you can configure both build preset-specific environment variables and those required for the component build.
 
-For example, if you want to override the Maven command of the  **Java** build presets, you can use `GOOGLE_MAVEN_BUILD_ARGS` as the environment key and `clean install` as the value.
+For example, if you want to override the Maven command of the **Java** build presets, you can use `GOOGLE_MAVEN_BUILD_ARGS` as the environment key and `clean install` as the value.
 
 For more examples, see [Google Cloud's buildpacks documentation](https://cloud.google.com/docs/buildpacks/service-specific-configs)..
 


### PR DESCRIPTION
## Description
> This pull request updates the documentation to clarify how to configure build-time environment variables for both Buildpack and BYOC (Bring Your Own Container) components. The changes provide clearer guidance and examples for each deployment method.

**Documentation improvements:**

* Added a new section explaining how to configure build-time environment variables for BYOC components, including how these variables are passed as build arguments (ARG) during Docker image builds.
* Clarified the process for setting environment variables for Buildpack components, and improved the example for overriding Maven commands.
* Removed an external link and replaced it with a direct reference to Google Cloud's buildpacks documentation for additional examples.

Related issue - https://github.com/wso2-enterprise/choreo/issues/39214

## Type of change

- [ ] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [x] Change is applicable for both Developer and Platform Engineer views

## Testing

- [ ] Change is tested in Developer view
- [ ] Change is tested in Platform Engineer view

## Related issues
> List related issues here
