### PR TITLE
Update mkdocs.yml removing WSO2 Developer Platform Pipelines Specification page

### DIFF
--- a/en/pe-docs/mkdocs.yml
+++ b/en/pe-docs/mkdocs.yml
@@ -108,7 +108,6 @@ nav:
   - DevOps:
       - Automation Pipelines:
         - What are Automation Pipelines: devops/automation-pipelines/introduction.md
-        - WSO2 Developer Platform Pipelines Specification: devops/automation-pipelines/specification.md
         - Manage Automation Pipelines: devops/automation-pipelines/manage-automation-pipeline.md
         - Run Automation Pipelines: devops/automation-pipelines/run-automation-pipeline.md
         - Inbuilt Pipeline Templates: devops/automation-pipelines/inbuilt-templates.md


### PR DESCRIPTION


## Description
This pull request makes a minor change to the navigation structure in the documentation configuration file. It removes the link to the "WSO2 Developer Platform Pipelines Specification" from the Automation Pipelines section.

- Documentation navigation update:
  * Removed the "WSO2 Developer Platform Pipelines Specification" entry from the Automation Pipelines section in the `mkdocs.yml` file.

The specification is already pointed at https://wso2.com/engineering-platform/developer-platform/docs/platform-engineer/devops/automation-pipelines/introduction/ and there is no need to make it an inline md file (which we will have to maintain with specification changes)

## Type of change

- [ ] Change is only applicable for Developer view
- [x] Change is only applicable for Platform Engineer view
- [ ] Change is applicable for both Developer and Platform Engineer views

## Testing

- [ ] Change is tested in Developer view
- [x] Change is tested in Platform Engineer view

## Related issues
> List related issues here
