### PR TITLE
Add troubleshooting note for Go build issues

### DIFF
--- a/en/developer-docs/docs/develop-components/deploy-an-application-with-buildpacks.md
+++ b/en/developer-docs/docs/develop-components/deploy-an-application-with-buildpacks.md
@@ -187,3 +187,20 @@ e.g., <br>
 - java -jar target/sample.jar
 - node app.js
 - php -S 0.0.0.0:8000 index.php
+
+
+## Troubleshooting Go build issues
+
+If you encounter errors similar to:
+
+```bash
+package xxx/prisma/db is not found
+```
+
+ensure that:
+
+- all generated Prisma client files are committed to the repository
+- the correct Go module path is configured
+- generated directories are included before deployment
+
+This issue can occur during Buildpack-based deployments in Choreo when generated Prisma files are excluded from the Git repository.

--- a/en/developer-docs/docs/develop-components/deploy-an-application-with-buildpacks.md
+++ b/en/developer-docs/docs/develop-components/deploy-an-application-with-buildpacks.md
@@ -194,7 +194,7 @@ e.g., <br>
 If you encounter errors similar to:
 
 ```bash
-package xxx/prisma/db is not found
+package meal-planner-backend/prisma/db is not found
 ```
 
 ensure that:


### PR DESCRIPTION
## Description
Added a troubleshooting note for Go build issues related to missing generated Prisma client files during Buildpack-based deployments in Choreo

## Type of change

[x] Change is applicable for both Developer and Platform Engineer views

## Testing

[x] Change is tested in Developer view

## Related issues
N/A
