### PR TITLE
Update develop-an-integration-as-an-api-service.md

### DIFF
--- a/en/developer-docs/docs/develop-components/develop-integrations/develop-an-integration-as-an-api-service.md
+++ b/en/developer-docs/docs/develop-components/develop-integrations/develop-an-integration-as-an-api-service.md
@@ -18,7 +18,7 @@ In this guide, you will:
     - Read and accept the privacy policy and terms of use.
     - Click **Create**. This creates the organization and opens the **Project Home** page.
 
-## Step 1: Create the integration component
+## Step 01: Create the integration component
 
 1. Go to the [{{ product_name }} Console](https://console.choreo.dev/) and sign in. This opens the **Project Home** page.
 2. If you already have one or more components in your project, click **+ Create**. Otherwise, proceed to the next step.
@@ -45,7 +45,7 @@ In this guide, you will:
 8. Click **Create and Deploy**. {{ product_name }} initializes the component, builds it, and deploys it to the development environment.
 
 
-## Step 2: Test the integration
+## Step 02: Test the integration
 
 1. In the {{ product_name }} Console left navigation menu, click **Test** and then click **Console**.
 2. In the OpenAPI Console, select **Development** from the environment drop-down list.
@@ -58,7 +58,7 @@ In this guide, you will:
      {"Hello" : "Integration"}
      ```
 
-## Step 3: Observe the integration
+## Step 03: Observe the integration
 
 1. In the {{ product_name }} Console left navigation menu, click **Observability** and then select one of the following options to monitor the performance of the integration component:
     - **Alerts**: View and configure alerts based on predefined conditions.
@@ -67,7 +67,7 @@ In this guide, you will:
 
    For more details, see [Observability Overview](../../monitoring-and-insights/observability-overview.md).
 
-## Step 5: Publish the integration component
+## Step 04: Publish the integration component
 
 1. In the {{ product_name }} Console left navigation menu, click **Manage** and then click **Lifecycle**.
 2. The **Lifecycle Management** pane shows the current lifecycle stage as **Created**.

--- a/en/developer-docs/docs/develop-components/develop-integrations/develop-an-integration-as-an-api-service.md
+++ b/en/developer-docs/docs/develop-components/develop-integrations/develop-an-integration-as-an-api-service.md
@@ -44,7 +44,22 @@ In this guide, you will:
 
 8. Click **Create and Deploy**. {{ product_name }} initializes the component, builds it, and deploys it to the development environment.
 
-## Step 2: Test the integration
+## Step 2: Deploy the integration component
+
+To deploy the integration component to the development environment, follow the steps given below:
+
+1. In the {{ product_name }} Console left navigation menu, click **Deploy**.
+2. In the **Build Area** card, click **Configure & Deploy**.
+3. In the **Configurations** pane, click **Next**. This displays details of the endpoint ready to be deployed.
+4. Click **Deploy**. This deploys the integration component to the development environment.
+   The **Development** card indicates the **Deployment Status** as **Active** when the integration is successfully deployed.
+
+!!! tip
+    Automatic deployment is enabled for the component by default. Therefore, you are required to perform only the first deployment manually.
+
+Now you can test the integration.
+
+## Step 3: Test the integration
 
 1. In the {{ product_name }} Console left navigation menu, click **Test** and then click **Console**.
 2. In the OpenAPI Console, select **Development** from the environment drop-down list.

--- a/en/developer-docs/docs/develop-components/develop-integrations/develop-an-integration-as-an-api-service.md
+++ b/en/developer-docs/docs/develop-components/develop-integrations/develop-an-integration-as-an-api-service.md
@@ -18,7 +18,8 @@ In this guide, you will:
     - Read and accept the privacy policy and terms of use.
     - Click **Create**. This creates the organization and opens the **Project Home** page.
 
-## Step 01: Create the integration component
+
+## Step 1: Create the integration component
 
 1. Go to the [{{ product_name }} Console](https://console.choreo.dev/) and sign in. This opens the **Project Home** page.
 2. If you already have one or more components in your project, click **+ Create**. Otherwise, proceed to the next step.
@@ -45,7 +46,7 @@ In this guide, you will:
 8. Click **Create and Deploy**. {{ product_name }} initializes the component, builds it, and deploys it to the development environment.
 
 
-## Step 02: Test the integration
+## Step 2: Test the integration
 
 1. In the {{ product_name }} Console left navigation menu, click **Test** and then click **Console**.
 2. In the OpenAPI Console, select **Development** from the environment drop-down list.
@@ -58,7 +59,8 @@ In this guide, you will:
      {"Hello" : "Integration"}
      ```
 
-## Step 03: Observe the integration
+
+## Step 3: Observe the integration
 
 1. In the {{ product_name }} Console left navigation menu, click **Observability** and then select one of the following options to monitor the performance of the integration component:
     - **Alerts**: View and configure alerts based on predefined conditions.
@@ -67,7 +69,8 @@ In this guide, you will:
 
    For more details, see [Observability Overview](../../monitoring-and-insights/observability-overview.md).
 
-## Step 04: Publish the integration component
+
+## Step 4: Publish the integration component
 
 1. In the {{ product_name }} Console left navigation menu, click **Manage** and then click **Lifecycle**.
 2. The **Lifecycle Management** pane shows the current lifecycle stage as **Created**.

--- a/en/developer-docs/docs/develop-components/develop-integrations/develop-an-integration-as-an-api-service.md
+++ b/en/developer-docs/docs/develop-components/develop-integrations/develop-an-integration-as-an-api-service.md
@@ -44,22 +44,8 @@ In this guide, you will:
 
 8. Click **Create and Deploy**. {{ product_name }} initializes the component, builds it, and deploys it to the development environment.
 
-## Step 2: Deploy the integration component
 
-To deploy the integration component to the development environment, follow the steps given below:
-
-1. In the {{ product_name }} Console left navigation menu, click **Deploy**.
-2. In the **Build Area** card, click **Configure & Deploy**.
-3. In the **Configurations** pane, click **Next**. This displays details of the endpoint ready to be deployed.
-4. Click **Deploy**. This deploys the integration component to the development environment.
-   The **Development** card indicates the **Deployment Status** as **Active** when the integration is successfully deployed.
-
-!!! tip
-    Automatic deployment is enabled for the component by default. Therefore, you are required to perform only the first deployment manually.
-
-Now you can test the integration.
-
-## Step 3: Test the integration
+## Step 2: Test the integration
 
 1. In the {{ product_name }} Console left navigation menu, click **Test** and then click **Console**.
 2. In the OpenAPI Console, select **Development** from the environment drop-down list.
@@ -72,7 +58,7 @@ Now you can test the integration.
      {"Hello" : "Integration"}
      ```
 
-## Step 4: Observe the integration
+## Step 3: Observe the integration
 
 1. In the {{ product_name }} Console left navigation menu, click **Observability** and then select one of the following options to monitor the performance of the integration component:
     - **Alerts**: View and configure alerts based on predefined conditions.


### PR DESCRIPTION
The "Develop an integration as an API service" guide was missing Step 2: Deploy the integration component. The steps jumped from Step 1 (Create) directly to Step 2 (Test), skipping the deployment step entirely. Additionally, the step numbering jumped from Step 2 directly to Step 4 with no Step 3.

Changes made:
- Added missing Step 2: Deploy the integration component with all sub-steps
- Renamed the existing Step 2 (Test the integration) to Step 3

## Description
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

## Type of change

- [ ] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [x] Change is applicable for both Developer and Platform Engineer views

## Testing

- [ ] Change is tested in Developer view
- [ ] Change is tested in Platform Engineer view

## Related issues
> List related issues here
