### PR TITLE
doc: fix typo in Moesif image alt text

### DIFF
--- a/en/developer-docs/docs/monitoring-and-insights/integrate-choreo-with-moesif.md
+++ b/en/developer-docs/docs/monitoring-and-insights/integrate-choreo-with-moesif.md
@@ -75,7 +75,7 @@ You have configured {{ product_name }} to publish data to Moesif. Let's see how 
 
 2. Once you publish data, your Moesif dashboard will receive events. Once Moesif receives events, you will see a notification on Moesif confirming that it received data.
 
-    ![Data Recieved Moesif Notification](../assets/img/monitoring-and-insights/data_recieved_moesif_notification.png){.cInlineImage-small}
+    ![Data Received Moesif Notification](../assets/img/monitoring-and-insights/data_recieved_moesif_notification.png){.cInlineImage-small}
 
 3. Click **Next** on the notification. This will take you to the final step, where you can opt to add team members. In this guide, let's skip this step.
 4. Click **Finish**.

--- a/en/pe-docs/docs/api-management/api-analytics/integrate-choreo-with-moesif.md
+++ b/en/pe-docs/docs/api-management/api-analytics/integrate-choreo-with-moesif.md
@@ -72,7 +72,7 @@ Once you successfully add the key, you will see a delete option next to it. Curr
 
 2. Once you publish data, your Moesif dashboard will receive events. Once Moesif receives events, you will see a notification on Moesif confirming that it received data. 
 
-    ![Data Recieved Moesif Notification](../../assets/img/monitoring-and-insights/data_recieved_moesif_notification.png)
+    ![Data Received Moesif Notification](../../assets/img/monitoring-and-insights/data_recieved_moesif_notification.png)
 
 3. Click **Next** on the notification. This will take you to the final step, where you can opt to add team members. In this guide, let's skip this step. 
 4. Click **Finish**.


### PR DESCRIPTION
## Description

Corrected the spelling of "Received" in the Moesif notification image alt text.

## Type of change

- [ ] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [x] Change is applicable for both Developer and Platform Engineer views

## Testing

- [x] Change is tested in Developer view
- [x] Change is tested in Platform Engineer view

## Related issues

N/A