### PR TITLE
doc: fix spacing and punctuation in authentication guide

### DIFF
--- a/en/developer-docs/docs/authentication-and-authorization/secure-web-applications-with-managed-authentication.md
+++ b/en/developer-docs/docs/authentication-and-authorization/secure-web-applications-with-managed-authentication.md
@@ -195,7 +195,7 @@ You can enable managed authentication for your web application component at the 
 
 ## Step 3: Configure the identity provider for the web application
 
-You can configure your web application to work with the {{ product_name }} built-in identity provider, Asgardeo, or any external identity provider which supports OIDC/OAuth2.0 . 
+You can configure your web application to work with the {{ product_name }} built-in identity provider, Asgardeo, or any external identity provider which supports OIDC/OAuth2.0. 
 
 !!! note
     The identity provider configured in this step should contain the users for the web application.


### PR DESCRIPTION
## Description

Corrected spacing and punctuation issues in the managed authentication guide.

## Type of change

- [x] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [ ] Change is applicable for both Developer and Platform Engineer views

## Testing

- [x] Change is tested in Developer view
- [ ] Change is tested in Platform Engineer view

## Related issues

N/A