### PR TITLE
doc: fix broken user store guide link

### DIFF
--- a/en/developer-docs/docs/authentication-and-authorization/secure-web-applications-with-managed-authentication.md
+++ b/en/developer-docs/docs/authentication-and-authorization/secure-web-applications-with-managed-authentication.md
@@ -219,7 +219,7 @@ Click the respective tab for details depending on which identity provider you ne
              If the **Regenerate Secret** button is shown instead of the **Generate Secret** button, it indicates that OAuth keys are already generated for the component for the selected environment.
 
     !!! tip
-        Refer to [Configure a User Store with the Built-In Identity Provider](../../administer/configure-a-user-store-with-built-in-idp/) for details on adding test users in {{ product_name }} built-in identity provider.
+        Refer to [Configure a User Store with the Built-In Identity Provider](../../administer/configure-a-user-store-with-built-in-idp.md) for details on adding test users in {{ product_name }} built-in identity provider.
 
     !!! tip
         If you need to invoke APIs secured with role-based access control, you can test this within {{ product_name }} by creating roles for the application and mapping those roles to relevant permissions (scope) and user groups. For more information, see [create roles and assign permissions](../test-secure-api-access-with-{{ product_name }}-built-in-security-token-service/#step-2-create-roles-and-assign-permissions) and [assign roles to user groups](../test-secure-api-access-with-{{ product_name }}-built-in-security-token-service/#step-3-assign-roles-to-user-groups) sections in [Test Secure API Access with {{ product_name }} Built-In Security Token Service](../test-secure-api-access-with-{{ product_name }}-built-in-security-token-service).


### PR DESCRIPTION
## Description

Corrected the link to the built-in identity provider user store guide by referencing the markdown file directly.

## Type of change

- [x] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [ ] Change is applicable for both Developer and Platform Engineer views

## Testing

- [x] Change is tested in Developer view
- [ ] Change is tested in Platform Engineer view

## Related issues

N/A