### PR TITLE
doc: fix broken Azure AD documentation link

### DIFF
--- a/en/developer-docs/docs/authentication-and-authorization/secure-api-access-with-azure-ad.md
+++ b/en/developer-docs/docs/authentication-and-authorization/secure-api-access-with-azure-ad.md
@@ -74,7 +74,7 @@ You can restrict users to the API as follows:
 4. Under **Manage**, select the **Users and groups** then select **+ Add user/group**.
 5. Select the users and groups and click **Select**.
 
-For more information, refer to the Azure documentation: [Assign the app to users and groups to restrict access](Assign the app to users and groups to restrict access)
+For more information, refer to the Azure documentation: [Assign the app to users and groups to restrict access](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/assign-user-or-group-access-portal)
 
 ## Step 3: Create a client application on Azure AD and invoke the Azure web API
 


### PR DESCRIPTION
## Description

Corrected a broken Azure AD documentation link by replacing the placeholder link target with the official Microsoft documentation URL.

## Type of change

- [x] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [ ] Change is applicable for both Developer and Platform Engineer views

## Testing

- [x] Change is tested in Developer view
- [ ] Change is tested in Platform Engineer view

## Related issues

N/A