### PR TITLE
Document customizable CI under CI Pipelines

### DIFF
--- a/en/pe-docs/docs/devops/ci-pipelines/customizable-ci/author-pipeline-yaml.md
+++ b/en/pe-docs/docs/devops/ci-pipelines/customizable-ci/author-pipeline-yaml.md
@@ -1,0 +1,243 @@
+# Author pipeline.yaml
+
+A customizable CI pipeline is defined by a single `pipeline.yaml` document. This page covers the top-level structure, the step types you can use, the templates that back them, and the variables, secrets, and system variables available to your scripts.
+
+## Top-level structure
+
+A pipeline has three top-level sections, all optional except `steps`:
+
+```yaml
+steps:
+  # Ordered list of steps that make up the build.
+
+templates:
+  # Reusable scripts referenced by step.template.
+
+containerTemplates:
+  # Reusable container definitions referenced by containerSet entries.
+```
+
+`steps` controls execution order. `templates` and `containerTemplates` are libraries of reusable definitions you reference by name.
+
+## Steps
+
+Each step has a `name` and one of three execution forms.
+
+!!! note
+    The examples in this section focus on the syntax being illustrated. A pipeline you save must also include the [mandatory build step](#mandatory-steps) for the Build Preset it will be attached to. See [A complete example](#a-complete-example) at the bottom of this page for a full working pipeline.
+
+### Template step
+
+Runs a single template defined under `templates`. Use this when a step does one self-contained task.
+
+{% raw %}
+```yaml
+steps:
+  - name: Slack Notification
+    template: slack-notification
+
+templates:
+  - name: slack-notification
+    image: curlimages/curl:latest
+    inlineScript: |
+      #!/bin/sh
+      curl -X POST -H 'Content-type: application/json' \
+        --data '{"text":"Build succeeded"}' "$SLACK_WEBHOOK_URL"
+    env:
+      - name: SLACK_WEBHOOK_URL
+        value: '{{ORG.SECRETS.SLACK_WEBHOOK_URL}}'
+```
+{% endraw %}
+
+### Container-set step
+
+Runs several containers in a single pod, sharing the same workspace. Use this when multiple steps need to share files (for example, your tests run against the same source the build will use).
+
+```yaml
+steps:
+  - name: Build Steps
+    containerSet:
+      containers:
+        - name: Test
+          containerTemplate: go-test
+        - name: Build Component
+          containerTemplate: choreo/buildpack-build@v1
+        - name: Vulnerability Scan
+          containerTemplate: choreo/trivy-scan@v1
+
+containerTemplates:
+  - name: go-test
+    image: golang:latest
+    inlineScript: |
+      #!/bin/sh
+      cd "$SOURCE_ROOT"
+      go test ./...
+```
+
+Containers in a container set share the same workspace under `$WORKSPACE`. When you reference a built-in `choreo/*@v1` step from inside a container set, {{ product_name }} wires the order required between built-in steps automatically.
+
+### Inline step
+
+Runs an inline script directly without referencing a named template. Useful for short one-off steps.
+
+{% raw %}
+```yaml
+steps:
+  - name: Hello
+    image: alpine:latest
+    inlineScript: |
+      #!/bin/sh
+      echo "Hello from {{ORG.VARIABLES.GREETING_NAME}}"
+```
+{% endraw %}
+
+## Templates
+
+A `template` is a reusable step definition. Templates run as their own pod when referenced from a step.
+
+```yaml
+templates:
+  - name: <template-name>
+    image: <container image>
+    inlineScript: |
+      #!/bin/bash
+      ...
+    env:
+      - name: VAR_NAME
+        value: 'literal-or-variable-reference'
+```
+
+`image` is optional — if omitted, {{ product_name }} uses a default base image. `inlineScript` is a bash or sh script that runs inside the container. `env` is a list of environment variables; see [Variables and secrets](#variables-and-secrets) for the reference syntax.
+
+## Container templates
+
+A `containerTemplate` is the same shape as a `template`, but it is referenced from inside a `containerSet` rather than as a standalone step.
+
+```yaml
+containerTemplates:
+  - name: <container-template-name>
+    image: <container image>
+    inlineScript: |
+      #!/bin/sh
+      ...
+    env:
+      - name: VAR_NAME
+        value: 'literal-or-variable-reference'
+```
+
+Inside a `containerSet`, the `containerTemplate` field on each container entry references either one of these user-defined container templates by name, or one of {{ product_name }}'s [built-in steps](built-in-steps.md) by its `choreo/<name>@v1` identifier — for example, `containerTemplate: choreo/buildpack-build@v1`.
+
+## Variables and secrets
+
+Inside `env.value`, reference variables and secrets using the scoped syntax `{% raw %}{{SCOPE.TYPE.NAME}}{% endraw %}`, where:
+
+| Field | Allowed values |
+|---|---|
+| `SCOPE` | `ORG` (organization), `PROJECT` (project), or `DT` (deployment track) |
+| `TYPE` | `VARIABLES` or `SECRETS` |
+| `NAME` | The variable or secret name you defined in the Console |
+
+For example:
+
+{% raw %}
+```yaml
+env:
+  - name: SNYK_TOKEN
+    value: '{{ORG.SECRETS.SNYK_TOKEN}}'
+  - name: GO_VERSION
+    value: '{{DT.VARIABLES.GO_VERSION}}'
+```
+{% endraw %}
+
+### Scope precedence
+
+An explicit reference such as `{% raw %}{{ORG.SECRETS.MY_TOKEN}}{% endraw %}` or `{% raw %}{{DT.VARIABLES.MY_VAR}}{% endraw %}` resolves at exactly the named scope — no walk.
+
+The unqualified form `{% raw %}{{VARIABLES.X}}{% endraw %}` and `{% raw %}{{SECRETS.X}}{% endraw %}` is still accepted for backward compatibility and resolves by walking **DT → Project → Org** and using the first match. Prefer the explicit `{% raw %}{{SCOPE.TYPE.NAME}}{% endraw %}` form in new pipelines.
+
+You add the actual variable and secret values from the {{ product_name }} Console — see [Manage customizable CI pipelines](manage-customizable-ci-pipeline.md#add-variables-and-secrets).
+
+## System variables
+
+{{ product_name }} injects the following environment variables into every step. They are always available and do not need to be declared under `env`.
+
+| Variable | Description |
+|---|---|
+| `$WORKSPACE` | The shared workspace mount (`/mnt/vol`). Reset for each build. |
+| `$REPOSITORY_DIR` | The clone root of the component's source repository. |
+| `$SOURCE_ROOT` | The component's source directory. Equals `$REPOSITORY_DIR` for a root-level component, or `$REPOSITORY_DIR/<subpath>` in a monorepo. Use `cd "$SOURCE_ROOT"` to operate on the component without per-component conditionals. |
+| `$COMPONENT_SUBPATH` | The component subpath relative to the clone root. Empty when the component sits at the repo root. |
+| `$IMAGE_NAME` | The container image name {{ product_name }}'s built-in build steps produce (`choreo/app-image:latest`). |
+| `$CI_BRANCH` | The branch being built. |
+| `$CI_PIPELINE_ID` | The build run ID. |
+
+## Mandatory steps
+
+Every customizable CI pipeline must include the build step that produces the component image, otherwise {{ product_name }} rejects the YAML when you save it. The required step depends on the component's build preset:
+
+| Build preset | Required step |
+|---|---|
+| Buildpack | `choreo/buildpack-build@v1` |
+| BYOC (Docker) | `choreo/docker-build@v1` |
+| Ballerina Buildpack | `choreo/ballerina-build@v1` |
+| Web App | `choreo/webapp-build@v1` |
+| WSO2 MI | `choreo/build-preparation@v1`, `choreo/integration-project-build@v1` |
+| Prism Mock | `choreo/prism-build@v1` |
+| Test Runner | `choreo/test-runner-build@v1` |
+
+If a pipeline.yaml is missing the required step for the build preset it is attached to, the {{ product_name }} Console surfaces the missing step in the YAML editor and the build is not allowed to start. See [Built-in steps](built-in-steps.md) for the inputs and outputs each step expects.
+
+## A complete example
+
+The pipeline below is a working buildpack pipeline that runs unit tests, builds the component image, scans the image, and posts a Slack notification on completion. It uses every concept on this page — system variables, scoped variables and secrets, a user-defined container template, built-in steps inside a container set, and a stand-alone template step.
+
+{% raw %}
+```yaml
+steps:
+  - name: Build Steps
+    containerSet:
+      containers:
+        - name: Test
+          containerTemplate: go-test
+        - name: Build Component
+          containerTemplate: choreo/buildpack-build@v1
+        - name: Vulnerability Scan
+          containerTemplate: choreo/trivy-scan@v1
+
+  - name: Notify
+    template: slack-notification
+
+containerTemplates:
+  - name: go-test
+    image: golang:latest
+    inlineScript: |
+      #!/bin/sh
+      set -e
+      echo "Testing $CI_PIPELINE_ID on branch $CI_BRANCH"
+      cd "$SOURCE_ROOT"
+      go test ./...
+    env:
+      - name: GO_VERSION
+        value: '{{DT.VARIABLES.GO_VERSION}}'
+
+templates:
+  - name: slack-notification
+    image: curlimages/curl:latest
+    inlineScript: |
+      #!/bin/sh
+      MESSAGE=":white_check_mark: Build $CI_PIPELINE_ID for $CI_BRANCH succeeded"
+      curl -X POST -H 'Content-type: application/json' \
+        --data "$(printf '{"text":"%s"}' "$MESSAGE")" \
+        "$SLACK_WEBHOOK_URL"
+    env:
+      - name: SLACK_WEBHOOK_URL
+        value: '{{ORG.SECRETS.SLACK_WEBHOOK_URL}}'
+```
+{% endraw %}
+
+Before this pipeline can build:
+
+- Define `SLACK_WEBHOOK_URL` as an organization-level **Secret** on the pipeline.
+- Define `GO_VERSION` (for example, `1.22.0`) as a **Variable** at the deployment-track scope for each component that uses this pipeline.
+
+See [Manage customizable CI pipelines](manage-customizable-ci-pipeline.md#add-variables-and-secrets) for how to add these values from the Console.

--- a/en/pe-docs/docs/devops/ci-pipelines/customizable-ci/built-in-steps.md
+++ b/en/pe-docs/docs/devops/ci-pipelines/customizable-ci/built-in-steps.md
@@ -1,0 +1,56 @@
+# Built-in steps
+
+{{ product_name }} ships a set of pre-built CI steps you can call from a `pipeline.yaml` without writing your own container or script. Built-in steps handle the common build pipeline tasks — building the component, scanning for vulnerabilities, running unit tests, and so on — and they understand the conventions the rest of the build flow expects (where the source lives, how the image is named, how status is reported back to the Console).
+
+Call a built-in step from inside a `containerSet` by setting `containerTemplate` to the step's identifier:
+
+```yaml
+steps:
+  - name: Build Steps
+    containerSet:
+      containers:
+        - name: Build Component
+          containerTemplate: choreo/buildpack-build@v1
+```
+
+## Build steps
+
+These steps produce the component image. Each customizable CI pipeline must include the build step that matches the component's build preset (see [Mandatory steps](author-pipeline-yaml.md#mandatory-steps)).
+
+| Step | Build preset | What it does |
+|---|---|---|
+| `choreo/buildpack-build@v1` | Buildpack | Runs Cloud Native Buildpacks (`pack build`) at `$SOURCE_ROOT` and produces the component image. |
+| `choreo/docker-build@v1` | BYOC (Docker) | Builds the image from the component's `Dockerfile`. |
+| `choreo/ballerina-build@v1` | Ballerina Buildpack | Runs the Ballerina build and produces the component image. |
+| `choreo/webapp-build@v1` | Web App | Builds the web app (React, Angular, Vue, or static files) and produces the deployable image. |
+| `choreo/prism-build@v1` | Prism Mock | Builds a Prism mock service from the OpenAPI specification. |
+| `choreo/test-runner-build@v1` | Test Runner | Packages a Postman test collection runner. |
+| `choreo/build-preparation@v1` | WSO2 MI | Prepares the WSO2 MI build workspace (downloads dependencies, validates the project). Pair with `choreo/integration-project-build@v1`. |
+| `choreo/integration-project-build@v1` | WSO2 MI | Builds the WSO2 MI integration project. |
+| `choreo/mi-unit-test-preparation@v1` | WSO2 MI | Optional MI unit test preparation step. Pair with `choreo/mi-unit-test@v1`. |
+| `choreo/mi-unit-test@v1` | WSO2 MI | Optional MI unit test execution step. |
+| `choreo/buildpack-unit-test@v1` | Buildpack | Optional buildpack unit test step. See [Integrate Unit Tests into the CI Pipeline](../integrate-unit-tests-into-the-build-pipeline.md). |
+| `choreo/ballerina-unit-test@v1` | Ballerina | Optional Ballerina unit test step. |
+
+All build steps write the resulting image to a shared workspace location so subsequent steps (vulnerability scan, image push) can consume it directly.
+
+## Security and scanning steps
+
+| Step | What it does |
+|---|---|
+| `choreo/trivy-scan@v1` | Scans the image produced by the build step for vulnerabilities using Trivy. Honors a `.trivyignore` file at the component source root if present. |
+| `choreo/dockerfile-scan@v1` | Static analysis of the component's `Dockerfile` using Checkov. Used by BYOC components. |
+
+!!! info
+    `choreo/trivy-scan@v1` runs Trivy, `choreo/dockerfile-scan@v1` runs Checkov. They are not interchangeable. Buildpack flows that do not produce a `Dockerfile` cannot use `choreo/dockerfile-scan@v1`.
+
+## Step naming convention
+
+Built-in step identifiers follow the format `choreo/<step-name>@v<major>`. The version suffix is required. The current versions are listed above; existing pipelines continue to work when new versions are added.
+
+You can mix built-in steps with your own templates and container templates in the same pipeline — for example, a Snyk source scan you author before `choreo/buildpack-build@v1`, and a Slack notification after `choreo/trivy-scan@v1`.
+
+## What's next
+
+- [Author pipeline.yaml](author-pipeline-yaml.md) — full YAML syntax for steps, templates, and container templates.
+- [Manage customizable CI pipelines](manage-customizable-ci-pipeline.md) — create, attach, and update pipelines from the {{ product_name }} Console.

--- a/en/pe-docs/docs/devops/ci-pipelines/customizable-ci/introduction.md
+++ b/en/pe-docs/docs/devops/ci-pipelines/customizable-ci/introduction.md
@@ -1,0 +1,88 @@
+# What is Customizable CI
+
+{{ product_name }} runs every component build through a built-in CI pipeline that prepares the source, builds the image, scans it for vulnerabilities, and pushes it to your registry. For most components, this default pipeline is enough.
+
+**Customizable CI** lets you replace that default pipeline with one you author yourself in YAML. You decide which steps run, in what order, and what tools they use — for example, running a Snyk source scan and a SonarCloud quality gate before the build, running unit tests or other custom containers alongside the build step, scanning the built image with a third-party scanner like Snyk Container or Aqua in addition to (or instead of) the default Trivy scan, and posting a Slack notification on completion.
+
+!!! info
+    Customizable CI is available only on private data plane organizations and must be enabled by WSO2 on request.
+
+## When to use Customizable CI
+
+Use customizable CI when you need to:
+
+- **Run pre-build checks on the source** — vulnerability scans, license checks, code quality gates, secret detection, and similar.
+- **Run unit tests, linters, or other custom containers alongside the build step**.
+- **Scan the built image** with a third-party vulnerability scanner (Snyk Container, Aqua, Anchore, or any other OCI-compliant scanner) in addition to or instead of the default Trivy scan.
+- **Run post-build actions** like external notifications, approvals, or artifact publishing from inside the pipeline.
+- **Standardize a CI workflow** across components in a way the default pipeline doesn't allow.
+
+!!! note
+    Every customizable CI pipeline must still include the built-in build step for its Build Preset (for example, `choreo/buildpack-build@v1` for Buildpack components, `choreo/docker-build@v1` for BYOC). You can add your own steps around and alongside it, but the built-in build step itself can't be replaced today. See [Mandatory steps](author-pipeline-yaml.md#mandatory-steps) for the full list.
+
+If you only need to build and deploy a component with reasonable defaults, the [default CI pipeline](../configure-ci-pipeline.md) is simpler and requires no YAML.
+
+## How it works
+
+A customizable CI pipeline is a YAML document (`pipeline.yaml`) that defines the steps for a build. {{ product_name }} stores the pipeline at the **organization** level. Authoring and maintaining the pipeline YAML is a platform-engineer task. Once the pipeline exists, either a platform engineer or a developer can attach it to a project (which makes it available to components in that project) and then select it on the specific deployment track of a component that should use it, define the variables and secrets it expects at any scope, and review build validation errors when something fails.
+
+When a build triggers, {{ product_name }} converts the YAML into an Argo Workflow and runs it in the data plane build cluster.
+
+Inside each step you can:
+
+- Call a built-in step from {{ product_name }} (for example, `choreo/buildpack-build@v1`, `choreo/trivy-scan@v1`).
+- Run any container image you choose with an inline script.
+- Reference variables and secrets you've defined at the organization, project, or deployment-track scope.
+- Read system variables that {{ product_name }} injects (the component source path, the branch being built, the build run ID, and so on).
+
+The same `choreo/*` built-in steps the default pipeline uses are also available to you, so you can keep the parts you want and replace only the parts you want to change.
+
+## Quick start
+
+The smallest pipeline you can save and run for a Buildpack component is six lines — it just calls the built-in build step. Paste this into the YAML editor when you create a pipeline with **Build Preset: Buildpack** to confirm the feature works end to end:
+
+```yaml
+steps:
+  - name: Build
+    containerSet:
+      containers:
+        - name: Build Component
+          containerTemplate: choreo/buildpack-build@v1
+```
+
+The next pipeline adds a "Hello World" step that runs an arbitrary container with your own script before the build — the part you can replace with anything you want (a Snyk scan, a custom linter, a notification, etc.). The build step that follows is the mandatory one every Buildpack pipeline needs.
+
+```yaml
+steps:
+  - name: Hello
+    image: alpine:latest
+    inlineScript: |
+      #!/bin/sh
+      echo "Hello, World! Building $CI_BRANCH (build $CI_PIPELINE_ID)"
+  - name: Build
+    containerSet:
+      containers:
+        - name: Build Component
+          containerTemplate: choreo/buildpack-build@v1
+```
+
+A pipeline with a vulnerability scan after the build:
+
+```yaml
+steps:
+  - name: Build Steps
+    containerSet:
+      containers:
+        - name: Build Component
+          containerTemplate: choreo/buildpack-build@v1
+        - name: Vulnerability Scan
+          containerTemplate: choreo/trivy-scan@v1
+```
+
+From here you can add your own steps — for example, a Snyk source scan before the build, or a Slack notification after the scan. See [Author pipeline.yaml](author-pipeline-yaml.md) for the full syntax and a complete worked example, or [Built-in steps](built-in-steps.md) for the equivalent identifiers for other Build Presets (BYOC, Web App, Ballerina, MI, Prism Mock, Test Runner).
+
+## What's next
+
+- [Author pipeline.yaml](author-pipeline-yaml.md) — pipeline YAML syntax, steps, templates, variables, secrets, and system variables.
+- [Built-in steps](built-in-steps.md) — the `choreo/*` steps you can call from your pipeline.
+- [Manage customizable CI pipelines](manage-customizable-ci-pipeline.md) — create, attach, and update pipelines from the {{ product_name }} Console.

--- a/en/pe-docs/docs/devops/ci-pipelines/customizable-ci/manage-customizable-ci-pipeline.md
+++ b/en/pe-docs/docs/devops/ci-pipelines/customizable-ci/manage-customizable-ci-pipeline.md
@@ -1,0 +1,96 @@
+# Manage customizable CI pipelines
+
+A customizable CI pipeline lives at the organization level. Authoring and maintaining the pipeline YAML is a platform-engineer-only task. Making a pipeline take effect on a build is a two-step task that can be done by either a platform engineer or a developer: first attach the pipeline to the project (this makes it available in the project), then select it on the specific deployment track of a component that should use it. Defining the variables and secrets the pipeline expects at any scope, and reviewing build validation errors, can also be done by either role.
+
+!!! info
+    Customizable CI is available only on private data plane organizations and must be enabled by WSO2 on request.
+
+| Task | Who |
+|---|---|
+| Create a pipeline | Platform engineer |
+| Edit the pipeline YAML | Platform engineer |
+| Attach a pipeline to a project | Platform engineer or developer |
+| Attach a pipeline to a deployment track | Platform engineer or developer |
+| Add variables and secrets at any scope (organization, project, or deployment track) | Platform engineer or developer |
+| View pipeline validation errors after a build | Platform engineer or developer |
+
+## Create a pipeline
+
+You author a customizable CI pipeline by writing its YAML in the Console editor.
+
+1. In the {{ product_name }} Console, switch to the **Platform** view.
+2. In the top navigation menu, select the relevant **Organization**.
+3. In the left navigation menu, click **DevOps** and then click **CI Pipelines**.
+4. Click **Create a CI Pipeline**.
+5. Enter a **Name** and **Description** for the pipeline.
+6. Select the **Build Preset** that matches the components you will attach this pipeline to.
+7. Paste your pipeline content into the YAML editor. See [Author pipeline.yaml](author-pipeline-yaml.md) for the syntax.
+8. Click **Create**.
+
+The Console validates the YAML structure and required mandatory steps when you click **Create**. If the pipeline.yaml has structural problems or is missing the build step required for the selected Build Preset, the validation dialog opens with the specific issues. Fix them in the editor and click **Create** again.
+
+## Attach a pipeline
+
+For a deployment track to use a customizable CI pipeline, two steps are required, in order:
+
+1. **Attach the pipeline to the project** that contains the deployment track's component. This makes the pipeline visible in the project so it can be selected on individual deployment tracks. Attaching to the project alone does not activate the pipeline on any build.
+2. **Select the pipeline on each deployment track** that should use it, from the deployment track's Build Configurations page. Each deployment track of a component is configured individually — there is no component-wide attach. Repeat this for every deployment track that should use the customizable pipeline.
+
+### Step 1: Attach the pipeline to the project
+
+1. Switch to the **Platform** view in the {{ product_name }} Console.
+2. In the top navigation menu, select the **Organization** and then the **Project**.
+3. In the left navigation menu, click **DevOps** and then click **CI Pipelines**.
+4. Click **Add to Project**, select the organization-level pipeline you created, and confirm. The pipeline is now available to the project's components.
+
+### Step 2: Select the pipeline on a deployment track
+
+1. Switch to the **Development** view.
+2. Open the **Component** that contains the deployment track you want to configure.
+3. At the top of the page, switch to the **Deployment Track** you want to configure.
+4. In the left navigation menu, click **Build** and then click **Build Configurations**.
+5. Under **CI Pipeline**, select the pipeline from the dropdown.
+6. Click **Save**.
+
+The next build of that deployment track uses the customizable pipeline.
+
+## Add variables and secrets
+
+If your pipeline references variables or secrets — for example, `{% raw %}{{ORG.SECRETS.SNYK_TOKEN}}{% endraw %}` or `{% raw %}{{DT.VARIABLES.GO_VERSION}}{% endraw %}` — you need to define the values before the first build runs.
+
+Define values at the scope that matches the reference in your YAML. An explicit reference such as `{% raw %}{{ORG.SECRETS.X}}{% endraw %}` or `{% raw %}{{DT.VARIABLES.X}}{% endraw %}` resolves at exactly the named scope. The legacy unqualified `{% raw %}{{VARIABLES.X}}{% endraw %}` and `{% raw %}{{SECRETS.X}}{% endraw %}` form resolves by walking **DT → Project → Org** and using the first match.
+
+### Add organization-level variables and secrets
+
+1. Switch to the **Platform** view.
+2. In the top navigation menu, select the **Organization**.
+3. In the left navigation menu, click **DevOps** and then click **CI Pipelines**.
+4. Open the pipeline you created.
+5. Click the **Variables** tab to add variables, or the **Secrets** tab to add secrets.
+6. Click **+ Add Variable** (or **+ Add Secret**) and provide the name and value. Add one entry per name your YAML references.
+7. Click **Save**.
+
+### Add project or deployment-track scope
+
+Variables and secrets at the project and deployment-track scopes are managed from the same Build Configurations page used to attach the pipeline. Open the component, navigate to **Build** > **Build Configurations**, and use the **Variables** and **Secrets** sections to define values at the scope you need.
+
+## Edit the pipeline YAML
+
+1. Switch to the **Platform** view.
+2. In the top navigation menu, select the **Organization**.
+3. In the left navigation menu, click **DevOps** and then click **CI Pipelines**.
+4. Open the pipeline.
+5. Click **Edit Pipeline YAML**, make your changes, and click **Save**.
+
+The same validation that runs at create time runs again when you save — structural errors and missing mandatory steps are surfaced in the editor before the change is persisted.
+
+## View pipeline validation errors
+
+When a build runs against a pipeline that has a problem the validator could not catch at save time (for example, an unresolved variable reference, a missing required parameter, or an incompatible step input), the build fails fast and the **Build Details** panel shows the specific problem — for example, which variables or secrets are missing at which scope, or which mandatory step is missing. Fix the YAML or define the missing values, then trigger a new build.
+
+For build log details, see [CI Pipeline logs](../ci-pipeline-logs.md).
+
+## What's next
+
+- [Author pipeline.yaml](author-pipeline-yaml.md) — pipeline YAML syntax, steps, templates, variables, secrets, and system variables.
+- [Built-in steps](built-in-steps.md) — the `choreo/*` steps you can call from your pipeline.

--- a/en/pe-docs/mkdocs.yml
+++ b/en/pe-docs/mkdocs.yml
@@ -116,6 +116,11 @@ nav:
           - Integrate Unit Tests into the CI Pipeline: devops/ci-pipelines/integrate-unit-tests-into-the-build-pipeline.md
           - Configure a Mirror Registry for In-Dataplane Builds: devops/ci-pipelines/configure-mirror-registry-for-in-dataplane-builds.md
           - CI Pipeline logs: 'devops/ci-pipelines/ci-pipeline-logs.md'
+          - Customize CI Pipeline:
+              - Introduction: devops/ci-pipelines/customizable-ci/introduction.md
+              - Author pipeline.yaml: devops/ci-pipelines/customizable-ci/author-pipeline-yaml.md
+              - Built-in steps: devops/ci-pipelines/customizable-ci/built-in-steps.md
+              - Manage customizable CI pipelines: devops/ci-pipelines/customizable-ci/manage-customizable-ci-pipeline.md
       - CD Pipelines:
           - Deploy Applications using WSO2 Developer Platform CD Pipeline: devops/cd-pipelines/deploying-application-using-choreo-cd-pipeline.md
           - Manage CD Pipelines: 'devops/cd-pipelines/manage-continuous-deployment-pipelines.md'


### PR DESCRIPTION
## Summary

Adds platform-engineer documentation for the Customize CI Pipeline feature under the existing CI Pipelines section. The pages cover what customizable CI is and when to reach for it, the pipeline.yaml syntax with a complete working example, the catalogue of built-in `choreo/*@v1` steps, and the Console flow for creating a pipeline, attaching it to a project, selecting it on a deployment track, and managing variables and secrets at each scope.

## Change

Four new markdown pages under `en/pe-docs/docs/devops/ci-pipelines/customizable-ci/`:

- Introduction — what the feature is, when to use it, a Quick start with three progressively richer examples.
- Author pipeline.yaml — step forms, templates, container templates, variables and secrets, system variables, mandatory steps per Build Preset, and a complete worked example.
- Built-in steps — table of build and scanning steps with the Build Preset each one applies to.
- Manage customizable CI pipelines — Console walk-through for create, attach, variables and secrets, edit, and error review, including the platform-engineer-only authoring boundary and the two-step project-attach-then-deployment-track-select flow.

Navigation entry added under the existing CI Pipelines section in `en/pe-docs/mkdocs.yml` so the new pages appear as a nested sub-section.

## Related Issue

https://github.com/wso2-enterprise/choreo/issues/39697