### PR TITLE
Fix inconsistent heading names in configure-certificates-for-proxies.md

### DIFF
--- a/en/developer-docs/docs/choreo-concepts/choreo-marketplace.md
+++ b/en/developer-docs/docs/choreo-concepts/choreo-marketplace.md
@@ -1,7 +1,7 @@
 # {{ product_name }} Marketplace
 
 The {{ product_name }} Marketplace promotes and facilitates reusing and sharing services. It allows you to share all the services deployed in {{ product_name }}.
-You can easily browse and search available services within the Marketplace and refer to the service definitions, documentation, instructions on how you can use it, etc. 
+You can easily browse and search available services within the Marketplace and refer to the service definitions, documentation, and usage instructions.
 
 ![Internal Marketplace](../assets/img/choreo-concepts/marketplace/internal-marketplace.png){.cInlineImage-full}
 
@@ -40,7 +40,7 @@ You can click on the service card to open the detailed view of the service. The 
 - **API definition**: Includes the API definition for the service, extracted from the `component.yaml` file in the user repository. If an API definition is not provided, this tab will be empty.
 
     !!! note
-        If you are are currently using the `component-config.yaml` or `endpoints.yaml` configuration files, see the respective [migration guide](../develop-components/manage-component-source-configurations.md#migration-guide) for instructions on migrating to the recommended `component.yaml` configuration file.
+        If you are  currently using the `component-config.yaml` or `endpoints.yaml` configuration files, see the respective [migration guide](../develop-components/manage-component-source-configurations.md#migration-guide) for instructions on migrating to the recommended `component.yaml` configuration file.
 
 - **How to use**: Includes instructions on how to use the selected service. This includes instructions on [creating a connection](../develop-components/sharing-and-reusing/create-a-connection.md).
 

--- a/en/developer-docs/docs/devops-and-ci-cd/configure-certificates-for-proxies.md
+++ b/en/developer-docs/docs/devops-and-ci-cd/configure-certificates-for-proxies.md
@@ -15,7 +15,7 @@ To configure TLS certificates for a Proxy component's endpoints, follow the step
 3. Select a TLS/endpoint certificate from the dropdown. The dropdown lists certificates available at the organization level.
 4. Optionally, configure a separate certificate for the sandbox endpoint.
 
-## Deploy a proxy with endpoint certificate
+## Deploy a proxy with endpoint certificates
 
 To deploy a Proxy component with an endpoint certificate, follow the steps given below:
 
@@ -24,7 +24,7 @@ To deploy a Proxy component with an endpoint certificate, follow the steps given
 3. In the wizard, you can select or change TLS certificates for main endpoint and sandbox endpoint.
 4. Click **Save and Deploy** to deploy the component with the selected certificates.
 
-## Promote a proxy with certificate
+## Promote a proxy with certificates
 
 When promoting a Proxy component from a lower environment to a higher environment, you can change the certificates applied to the component:
 


### PR DESCRIPTION
## Summary
Two section headings used the singular "certificate" while the rest of the document and the third heading used the plural "certificates". This fix makes the headings consistent throughout the file.

## Changes
- "Deploy a proxy with endpoint certificate" → "Deploy a proxy with endpoint certificates"
- "Promote a proxy with certificate" → "Promote a proxy with certificates"