### PR TITLE
Fix typos and grammar in Choreo docs

### DIFF
--- a/en/developer-docs/docs/administer/configure-approvals-for-choreo-workflows.md
+++ b/en/developer-docs/docs/administer/configure-approvals-for-choreo-workflows.md
@@ -63,7 +63,7 @@ To set up an approval process for a workflow, follow these steps:
     Both Roles and Assignees are optional configuration fields. If neither is specified, the system will not dispatch any notifications. However, users with the necessary permissions can still log in to the system and review approval requests through the interface.
 
     !!! info "Important"
-         Only roles having [relevant approval permission](#permissions-to-review-and-respond-to-approval-requests) can be selected to receive notifications, so that respective users can always review and respond to requests. However, users in Assignees field are there for notification purpose only, they may not have required priviledges to review and approve requests.
+         Only roles having [relevant approval permission](#permissions-to-review-and-respond-to-approval-requests) can be selected to receive notifications, so that respective users can always review and respond to requests. However, users in Assignees field are there for notification purpose only, they may not have required privileges to review and approve requests.
 
 
 7. Click **Save**. This configures notifications and enables the approval process for the workflow.

--- a/en/developer-docs/docs/choreo-concepts/choreo-marketplace.md
+++ b/en/developer-docs/docs/choreo-concepts/choreo-marketplace.md
@@ -40,7 +40,7 @@ You can click on the service card to open the detailed view of the service. The 
 - **API definition**: Includes the API definition for the service, extracted from the `component.yaml` file in the user repository. If an API definition is not provided, this tab will be empty.
 
     !!! note
-        If you are are currently using the `component-config.yaml` or `endpoints.yaml` configuration files, see the respective [migration guide](../develop-components/manage-component-source-configurations.md#migration-guide) for instructions on migrating to the recommended `component.yaml` configuration file.
+        If you are currently using the `component-config.yaml` or `endpoints.yaml` configuration files, see the respective [migration guide](../develop-components/manage-component-source-configurations.md#migration-guide) for instructions on migrating to the recommended `component.yaml` configuration file.
 
 - **How to use**: Includes instructions on how to use the selected service. This includes instructions on [creating a connection](../develop-components/sharing-and-reusing/create-a-connection.md).
 

--- a/en/developer-docs/docs/monitoring-and-insights/integrate-choreo-with-moesif.md
+++ b/en/developer-docs/docs/monitoring-and-insights/integrate-choreo-with-moesif.md
@@ -75,7 +75,7 @@ You have configured {{ product_name }} to publish data to Moesif. Let's see how 
 
 2. Once you publish data, your Moesif dashboard will receive events. Once Moesif receives events, you will see a notification on Moesif confirming that it received data.
 
-    ![Data Recieved Moesif Notification](../assets/img/monitoring-and-insights/data_recieved_moesif_notification.png){.cInlineImage-small}
+    ![Data Received Moesif Notification](../assets/img/monitoring-and-insights/data_recieved_moesif_notification.png){.cInlineImage-small}
 
 3. Click **Next** on the notification. This will take you to the final step, where you can opt to add team members. In this guide, let's skip this step.
 4. Click **Finish**.

--- a/en/pe-docs/docs/api-management/api-analytics/integrate-choreo-with-moesif.md
+++ b/en/pe-docs/docs/api-management/api-analytics/integrate-choreo-with-moesif.md
@@ -72,7 +72,7 @@ Once you successfully add the key, you will see a delete option next to it. Curr
 
 2. Once you publish data, your Moesif dashboard will receive events. Once Moesif receives events, you will see a notification on Moesif confirming that it received data. 
 
-    ![Data Recieved Moesif Notification](../../assets/img/monitoring-and-insights/data_recieved_moesif_notification.png)
+    ![Data Received Moesif Notification](../../assets/img/monitoring-and-insights/data_recieved_moesif_notification.png)
 
 3. Click **Next** on the notification. This will take you to the final step, where you can opt to add team members. In this guide, let's skip this step. 
 4. Click **Finish**.

--- a/en/pe-docs/docs/db-and-services/databases/choreo-managed-databases-and-caches.md
+++ b/en/pe-docs/docs/db-and-services/databases/choreo-managed-databases-and-caches.md
@@ -44,7 +44,7 @@ MySQL is a user-friendly, flexible, open-source relational database management s
 
 ## {{ product_name }}-Managed Cache (Valkey - OSS Redis Compatible)
 
-A fully managed cache compatible powered by Valkey that's fully compatible with with Redis® OSS. A versatile, in‑memory NoSQL database that serves as a cache, database, streaming engine, and message broker. {{ product_name }}-managed Cache allows you to have fully managed instances that can be swiftly provisioned and integrated into your applications within minutes.
+A fully managed cache powered by Valkey that's fully compatible with Redis® OSS. A versatile, in‑memory NoSQL database that serves as a cache, database, streaming engine, and message broker. {{ product_name }}-managed Cache allows you to have fully managed instances that can be swiftly provisioned and integrated into your applications within minutes.
 
 - [Create a {{ product_name }}-managed Cache](./choreo-managed-caches.md)
 

--- a/en/pe-docs/docs/devops/automation-pipelines/manage-automation-pipeline.md
+++ b/en/pe-docs/docs/devops/automation-pipelines/manage-automation-pipeline.md
@@ -1,6 +1,6 @@
 # Create Automation Pipelines
 
-{{ product_name }} allows to define automation pipelines at organization level. Follow these steps to create an automation pipeline.
+{{ product_name }} allows you to define automation pipelines at organization level. Follow these steps to create an automation pipeline.
 
 1. Sign in to the [{{ product_name }} Console](https://console.choreo.dev/).
 2. Open **Platform Operations** perspective.


### PR DESCRIPTION
## Description
> Fixes minor typos and grammar issues in the Choreo documentation. No structural or content-meaning changes.

- `privileges` (was `priviledges`) — Configure Approvals page
- Removed duplicate words: `are are` (Marketplace), `with with` (Managed Databases & Caches)
- Removed a stray `compatible` in the Valkey/Redis cache description
- `allows you to define` (was `allows to define`) — Automation Pipelines
- `Received` (was `Recieved`) in image alt text — Moesif integration pages (developer + platform views)

## Type of change

- [ ] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [x] Change is applicable for both Developer and Platform Engineer views

## Testing

- [ ] Change is tested in Developer view
- [ ] Change is tested in Platform Engineer view

Text-only typo fixes with no structural/Markdown changes; verified via the diff that admonition indentation and formatting are unchanged.

## Related issues
> N/A - minor typo/grammar fixes.
