### PR TITLE
Update docs to reflect support for ECC certificates

### DIFF
--- a/en/developer-docs/docs/administer/configure-a-custom-domain-for-your-organization.md
+++ b/en/developer-docs/docs/administer/configure-a-custom-domain-for-your-organization.md
@@ -77,7 +77,7 @@ To add a custom domain for your organization, follow the steps given below:
                 - For wildcard entries, the SSL file should use a wildcard notation to cover all subdomains under the provided URL. For example, if the CNAME is `apis.hello.dev`, the SSL file should use `*.hello.dev`.
           - TLS key file guidelines:
              - It should be in the PEM format.
-             - It must be encrypted using RSA encryption.
+             - It must use either RSA or elliptic curve cryptography (ECC). For ECC keys, use a supported curve, such as P-256 (prime256v1). The key algorithm must match that of the corresponding TLS certificate.
           - Certificate chain file guidelines:
              - The chain file, which is essential for some clients to verify the authenticity of a server's SSL/TLS certificate, should contain your domain's SSL/TLS certificate (optional, as this can be provided via the certificate itself) and one or more intermediate certificates in the correct order, leading back to a root certificate. 
              - All certificates in the chain should be X509 certificates in PEM format.

--- a/en/pe-docs/docs/infrastructure/domains/configure-a-custom-domain-for-your-organization.md
+++ b/en/pe-docs/docs/infrastructure/domains/configure-a-custom-domain-for-your-organization.md
@@ -71,7 +71,7 @@ To add a custom domain for your organization, follow the steps given below:
                 - For wildcard entries, the SSL file should use a wildcard notation to cover all subdomains under the provided URL. For example, if the CNAME is `apis.choreo.dev`, the SSL file should use `*.choreo.dev`.
           - TLS key file guidelines:
              - It should be in the PEM format.
-             - It must be encrypted using RSA encryption.
+             - It must use either RSA or elliptic curve cryptography (ECC). For ECC keys, use a supported curve, such as P-256 (prime256v1). The key algorithm must match that of the corresponding TLS certificate.
           - Certificate chain file guidelines:
              - The chain file, which is essential for some clients to verify the authenticity of a server's SSL/TLS certificate, should contain your domain's SSL/TLS certificate (optional, as this can be provided via the certificate itself) and one or more intermediate certificates in the correct order, leading back to a root certificate.
              - All certificates in the chain should be X509 certificates in PEM format.


### PR DESCRIPTION
## Description
> This pull request updates the documentation for configuring custom domains to clarify the supported types of TLS key algorithms. The main change is that both RSA and elliptic curve cryptography (ECC) keys are now explicitly supported, with guidance on using a supported ECC curve and ensuring the key algorithm matches the certificate.

Documentation updates for TLS key requirements:

* Updated the TLS key file guidelines in `en/developer-docs/docs/administer/configure-a-custom-domain-for-your-organization.md` to state that the key can use RSA or ECC (with a supported curve such as P-256), and that the key algorithm must match the certificate.
* Made the same update to the TLS key file guidelines in `en/pe-docs/docs/infrastructure/domains/configure-a-custom-domain-for-your-organization.md`.

Related issue - https://github.com/wso2-enterprise/choreo/issues/30310

## Type of change

- [ ] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [x] Change is applicable for both Developer and Platform Engineer views

## Testing

- [ ] Change is tested in Developer view
- [ ] Change is tested in Platform Engineer view

## Related issues
> List related issues here
