### PR TITLE
Add a new section clarifying that the source repository cannot be changed after creating a component

### DIFF
--- a/en/developer-docs/docs/develop-components/develop-components-with-git.md
+++ b/en/developer-docs/docs/develop-components/develop-components-with-git.md
@@ -10,7 +10,10 @@ In {{ product_name }}, you can connect a Git repository that contains Ballerina 
  - A Dockerfile: Specifies the instructions to build the Docker image. 
  - A build context: A set of files in the specified path used to build the image.
 
-Once you connect your Git repository to {{ product_name }}, you can build, deploy, and manage your application easily. 
+Once you connect your Git repository to {{ product_name }}, you can build, deploy, and manage your application easily. {{ product_name }} binds each component to the repository you select when you create it.
+
+!!! note
+    You cannot change the source repository name after a component is created. If you rename the repository in your Git provider or want to point the component to a different repository, you must create a new component with the required repository.
 
 ## Connect a Git repository to {{ product_name }}
 


### PR DESCRIPTION
## Description
> 
This pull request updates the documentation to clarify how components are bound to Git repositories in `{{ product_name }}` and adds an important note about repository renaming. The most important changes are:

**Documentation improvements:**

* Clarified that each component in `{{ product_name }}` is bound to the repository selected during creation.
* Added a note explaining that the source repository name cannot be changed after a component is created; to use a different repository, a new component must be created.

Related issue - https://github.com/wso2-enterprise/choreo/issues/40266

## Type of change

- [ ] Change is only applicable for Developer view
- [ ] Change is only applicable for Platform Engineer view
- [x] Change is applicable for both Developer and Platform Engineer views

## Testing

- [ ] Change is tested in Developer view
- [ ] Change is tested in Platform Engineer view

## Related issues
> List related issues here
